### PR TITLE
Feat(#15): 표 및 이미지 추출로직 개선 

### DIFF
--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -21,6 +21,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from playwright.async_api import async_playwright
 
 from .config import AI_ENABLED, CRAWL_INTERVAL_MINUTES, DETAIL_URL_TEMPLATE, GEMINI_API_KEY, GEMINI_MODEL, HEADLESS, PAGE_TIMEOUT, RAW_STORE_DIR, SOURCES
+from .content import build_content_payload
 from .db import create_crawl_job, finish_crawl_job, log_parse
 from .extractor import extract_key_info_with_ai
 from .file_handler import extract_external_images, extract_inline_images, process_attachments
@@ -122,11 +123,16 @@ async def run_source(browser, source: dict, seen_hashes: set) -> dict:
                     title=item.get("title", ""),
                     notice_date=item.get("date", ""),
                 )
+                content_payload = build_content_payload(
+                    detail.get("body_html", ""),
+                    attachments,
+                )
 
                 notice = {
                     **item,
                     "body_text": detail.get("body_text", ""),
                     "body_html": detail.get("body_html", ""),
+                    **content_payload,
                     "category": detail.get("category", ""),
                     "source_id": source["id"],
                     "attachments": attachments,
@@ -245,17 +251,26 @@ def run_startup_reextract() -> None:
 
     # null 필드가 있는 파일만 추려서 처리 대상 파악
     todo = []
+    content_updated = 0
     for path in files:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except Exception as exc:
             log.warning(f"[startup] {path.name} 읽기 실패: {exc}")
             continue
+        attachments = data.get("attachments") or []
+        content_payload = build_content_payload(data.get("body_html") or "", attachments)
+        if any(data.get(k) != v for k, v in content_payload.items()):
+            data.update(content_payload)
+            path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            content_updated += 1
         if not (data.get("deadline") is not None and data.get("target") is not None and data.get("apply_method") is not None):
             body_text = data.get("body_text") or ""
-            attachments = data.get("attachments") or []
             if body_text or any(a.get("extracted_text") for a in attachments):
                 todo.append(path)
+
+    if content_updated:
+        log.info(f"[startup] content_html updated: {content_updated}")
 
     if not todo:
         log.info(f"[startup] 재추출 불필요 — {len(files)}개 파일 이미 최신 상태")

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -14,6 +14,7 @@ Pipeline 흐름:
 
 import asyncio
 import logging
+import os
 import sys
 from datetime import datetime, timezone
 
@@ -34,6 +35,10 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 log = logging.getLogger("campost.runner")
+
+
+def _env_flag(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _launch_args() -> list[str]:
@@ -250,6 +255,7 @@ def run_startup_reextract() -> None:
         return
 
     # null 필드가 있는 파일만 추려서 처리 대상 파악
+    backfill_content = _env_flag("CAMPOST_BACKFILL_CONTENT_ON_STARTUP")
     todo = []
     content_updated = 0
     for path in files:
@@ -258,15 +264,21 @@ def run_startup_reextract() -> None:
         except Exception as exc:
             log.warning(f"[startup] {path.name} 읽기 실패: {exc}")
             continue
-        attachments = data.get("attachments") or []
-        content_payload = build_content_payload(data.get("body_html") or "", attachments)
-        if any(data.get(k) != v for k, v in content_payload.items()):
-            data.update(content_payload)
-            path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-            content_updated += 1
+        raw_attachments = data.get("attachments") or []
+        attachments = raw_attachments if isinstance(raw_attachments, list) else []
+        if backfill_content:
+            try:
+                content_payload = build_content_payload(data.get("body_html") or "", attachments)
+            except Exception as exc:
+                log.warning(f"[startup] {path.name} content_html generation failed: {exc}")
+            else:
+                if any(data.get(k) != v for k, v in content_payload.items()):
+                    data.update(content_payload)
+                    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+                    content_updated += 1
         if not (data.get("deadline") is not None and data.get("target") is not None and data.get("apply_method") is not None):
             body_text = data.get("body_text") or ""
-            if body_text or any(a.get("extracted_text") for a in attachments):
+            if body_text or any(a.get("extracted_text") for a in attachments if isinstance(a, dict)):
                 todo.append(path)
 
     if content_updated:
@@ -292,7 +304,8 @@ def run_startup_reextract() -> None:
         old_apply_method = data.get("apply_method")
 
         body_text   = data.get("body_text") or ""
-        attachments = data.get("attachments") or []
+        raw_attachments = data.get("attachments") or []
+        attachments = raw_attachments if isinstance(raw_attachments, list) else []
 
         # AI 호출 전 딜레이 (첫 번째 호출 제외)
         if GEMINI_API_KEY and ai_call_count > 0:

--- a/crawler/content.py
+++ b/crawler/content.py
@@ -1,0 +1,224 @@
+"""
+Render-oriented notice content helpers.
+
+The crawler keeps the original body_html for auditability and also writes a
+frontend-ready content_html field. content_html rewrites downloaded body images
+to local file paths and appends image attachments that were not embedded in the
+source body.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from copy import deepcopy
+
+IMAGE_EXTS = {"jpg", "jpeg", "png", "gif", "webp", "svg"}
+
+_IMG_SRC_RE = re.compile(
+    r"(<img\b[^>]*?\bsrc\s*=\s*)([\"'])(.*?)(\2)",
+    re.IGNORECASE | re.DOTALL,
+)
+_SCRIPT_STYLE_RE = re.compile(
+    r"<\s*(script|style|iframe|object|embed)\b[^>]*>.*?<\s*/\s*\1\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+_DANGEROUS_SINGLE_TAG_RE = re.compile(
+    r"<\s*(script|style|iframe|object|embed|meta|link)\b[^>]*?/?>",
+    re.IGNORECASE | re.DOTALL,
+)
+_EVENT_ATTR_RE = re.compile(
+    r"\s+on[a-zA-Z]+\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s>]+)",
+    re.IGNORECASE | re.DOTALL,
+)
+_JS_URL_ATTR_RE = re.compile(
+    r"\s+(href|src)\s*=\s*([\"'])\s*javascript:[^\"']*\2",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _normalize_ext(value: str | None) -> str:
+    return (value or "").rsplit(".", 1)[-1].lower().strip()
+
+
+def is_image_attachment(attachment: dict) -> bool:
+    mime_type = (attachment.get("mime_type") or "").lower()
+    ext = _normalize_ext(attachment.get("ext") or attachment.get("name"))
+    return mime_type.startswith("image/") or ext in IMAGE_EXTS
+
+
+def _is_downloaded(attachment: dict) -> bool:
+    return bool(attachment.get("download_ok") and attachment.get("local_path"))
+
+
+def _strip_unsafe_html(value: str) -> str:
+    cleaned = _SCRIPT_STYLE_RE.sub("", value or "")
+    cleaned = _DANGEROUS_SINGLE_TAG_RE.sub("", cleaned)
+    cleaned = _EVENT_ATTR_RE.sub("", cleaned)
+    cleaned = _JS_URL_ATTR_RE.sub("", cleaned)
+    return cleaned
+
+
+def _body_image_attachments(attachments: list[dict]) -> tuple[dict[str, dict], list[dict]]:
+    by_url: dict[str, dict] = {}
+    inline_images: list[dict] = []
+
+    for attachment in attachments:
+        if not (is_image_attachment(attachment) and _is_downloaded(attachment)):
+            continue
+
+        url = (attachment.get("url") or "").strip()
+        name = attachment.get("name") or ""
+        if url:
+            by_url[url] = attachment
+        elif "_inline_img_" in name or "inline_img_" in name:
+            inline_images.append(attachment)
+
+    return by_url, inline_images
+
+
+def _rewrite_body_image_sources(
+    body_html: str,
+    attachments: list[dict],
+) -> tuple[str, list[dict], set[str]]:
+    by_url, inline_images = _body_image_attachments(attachments)
+    inline_index = 0
+    used_file_keys: set[str] = set()
+    body_images: list[dict] = []
+
+    def replace(match: re.Match) -> str:
+        nonlocal inline_index
+
+        prefix, quote, src, suffix = match.groups()
+        src = (src or "").strip()
+        attachment = None
+
+        if src.startswith("data:image/"):
+            if inline_index < len(inline_images):
+                attachment = inline_images[inline_index]
+                inline_index += 1
+        else:
+            attachment = by_url.get(src)
+
+        if not attachment:
+            return match.group(0)
+
+        local_path = attachment["local_path"]
+        file_key = attachment.get("file_key") or attachment.get("name") or local_path
+        used_file_keys.add(file_key)
+        body_images.append(
+            {
+                "file_key": file_key,
+                "name": attachment.get("name") or file_key,
+                "src": local_path,
+                "original_src": src,
+                "mime_type": attachment.get("mime_type"),
+                "file_size": attachment.get("file_size"),
+            }
+        )
+        return f'{prefix}{quote}{html.escape(local_path, quote=True)}{suffix}'
+
+    return _IMG_SRC_RE.sub(replace, body_html or ""), body_images, used_file_keys
+
+
+def _image_attachment_gallery(
+    attachments: list[dict],
+    used_file_keys: set[str],
+) -> tuple[str, list[dict]]:
+    figures: list[str] = []
+    gallery_images: list[dict] = []
+
+    for attachment in attachments:
+        if not (is_image_attachment(attachment) and _is_downloaded(attachment)):
+            continue
+
+        file_key = attachment.get("file_key") or attachment.get("name") or attachment["local_path"]
+        if file_key in used_file_keys:
+            continue
+
+        name = attachment.get("name") or file_key
+        src = attachment["local_path"]
+        gallery_images.append(
+            {
+                "file_key": file_key,
+                "name": name,
+                "src": src,
+                "original_src": attachment.get("url") or "",
+                "mime_type": attachment.get("mime_type"),
+                "file_size": attachment.get("file_size"),
+            }
+        )
+        figures.append(
+            "<figure class=\"notice-content-image\">"
+            f"<img src=\"{html.escape(src, quote=True)}\" "
+            f"alt=\"{html.escape(name, quote=True)}\" loading=\"lazy\">"
+            f"<figcaption>{html.escape(name)}</figcaption>"
+            "</figure>"
+        )
+
+    if not figures:
+        return "", gallery_images
+
+    return (
+        "<section class=\"notice-content-image-attachments\">"
+        + "".join(figures)
+        + "</section>"
+    ), gallery_images
+
+
+def build_content_payload(body_html: str, attachments: list[dict] | None) -> dict:
+    """
+    Build render-ready fields from the raw notice body and downloaded files.
+
+    Returns fields that can be merged into the raw notice JSON:
+      - content_html: sanitized, render-ready HTML
+      - content_assets: image/file metadata for API consumers
+      - content_stats: quick counts for importer/tests
+    """
+    attachments = attachments or []
+    safe_body_html = _strip_unsafe_html(body_html or "")
+    rewritten_html, body_images, used_file_keys = _rewrite_body_image_sources(
+        safe_body_html,
+        attachments,
+    )
+    gallery_html, gallery_images = _image_attachment_gallery(attachments, used_file_keys)
+    content_html = (rewritten_html + gallery_html).strip()
+
+    downloadable_files = [
+        {
+            "file_key": attachment.get("file_key"),
+            "name": attachment.get("name"),
+            "local_path": attachment.get("local_path"),
+            "mime_type": attachment.get("mime_type"),
+            "file_size": attachment.get("file_size"),
+            "ext": attachment.get("ext"),
+        }
+        for attachment in attachments
+        if _is_downloaded(attachment) and not is_image_attachment(attachment)
+    ]
+
+    images = body_images + gallery_images
+    return {
+        "content_html": content_html,
+        "content_assets": {
+            "images": images,
+            "files": downloadable_files,
+        },
+        "content_stats": {
+            "image_count": len(images),
+            "file_count": len(downloadable_files),
+            "table_count": len(re.findall(r"<\s*table\b", content_html, re.IGNORECASE)),
+        },
+    }
+
+
+def attach_content_payload(notice: dict) -> dict:
+    """Return a notice copy with render-ready content fields attached."""
+    result = deepcopy(notice)
+    result.update(
+        build_content_payload(
+            result.get("body_html") or "",
+            result.get("attachments") or [],
+        )
+    )
+    return result

--- a/crawler/content.py
+++ b/crawler/content.py
@@ -10,30 +10,75 @@ source body.
 from __future__ import annotations
 
 import html
-import re
 from copy import deepcopy
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup, Comment
 
 IMAGE_EXTS = {"jpg", "jpeg", "png", "gif", "webp", "svg"}
 
-_IMG_SRC_RE = re.compile(
-    r"(<img\b[^>]*?\bsrc\s*=\s*)([\"'])(.*?)(\2)",
-    re.IGNORECASE | re.DOTALL,
-)
-_SCRIPT_STYLE_RE = re.compile(
-    r"<\s*(script|style|iframe|object|embed)\b[^>]*>.*?<\s*/\s*\1\s*>",
-    re.IGNORECASE | re.DOTALL,
-)
-_DANGEROUS_SINGLE_TAG_RE = re.compile(
-    r"<\s*(script|style|iframe|object|embed|meta|link)\b[^>]*?/?>",
-    re.IGNORECASE | re.DOTALL,
-)
-_EVENT_ATTR_RE = re.compile(
-    r"\s+on[a-zA-Z]+\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s>]+)",
-    re.IGNORECASE | re.DOTALL,
-)
-_JS_URL_ATTR_RE = re.compile(
-    r"\s+(href|src)\s*=\s*([\"'])\s*javascript:[^\"']*\2",
-    re.IGNORECASE | re.DOTALL,
+_DANGEROUS_TAGS = {"script", "style", "iframe", "object", "embed", "meta", "link"}
+_ALLOWED_TAGS = {
+    "a",
+    "b",
+    "blockquote",
+    "br",
+    "caption",
+    "code",
+    "col",
+    "colgroup",
+    "dd",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "figcaption",
+    "figure",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "i",
+    "img",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "s",
+    "section",
+    "small",
+    "span",
+    "strong",
+    "sub",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+    "u",
+    "ul",
+}
+_GLOBAL_ATTRS = {"class", "title"}
+_TAG_ATTRS = {
+    "a": {"href", "target", "rel"},
+    "col": {"span"},
+    "img": {"src", "alt", "loading", "height", "width"},
+    "td": {"colspan", "rowspan", "headers"},
+    "th": {"colspan", "rowspan", "headers", "scope"},
+}
+_SAFE_HREF_SCHEMES = {"", "http", "https", "mailto", "tel"}
+_SAFE_SRC_SCHEMES = {"", "http", "https"}
+_SAFE_DATA_IMAGE_PREFIXES = (
+    "data:image/jpeg;base64,",
+    "data:image/png;base64,",
+    "data:image/gif;base64,",
+    "data:image/webp;base64,",
 )
 
 
@@ -51,12 +96,52 @@ def _is_downloaded(attachment: dict) -> bool:
     return bool(attachment.get("download_ok") and attachment.get("local_path"))
 
 
-def _strip_unsafe_html(value: str) -> str:
-    cleaned = _SCRIPT_STYLE_RE.sub("", value or "")
-    cleaned = _DANGEROUS_SINGLE_TAG_RE.sub("", cleaned)
-    cleaned = _EVENT_ATTR_RE.sub("", cleaned)
-    cleaned = _JS_URL_ATTR_RE.sub("", cleaned)
-    return cleaned
+def _is_safe_href(value: str) -> bool:
+    parsed = urlparse((value or "").strip())
+    return parsed.scheme.lower() in _SAFE_HREF_SCHEMES
+
+
+def _is_safe_src(value: str) -> bool:
+    src = (value or "").strip()
+    if src.startswith(_SAFE_DATA_IMAGE_PREFIXES):
+        return True
+    if src.startswith("files/"):
+        return True
+    parsed = urlparse(src)
+    return parsed.scheme.lower() in _SAFE_SRC_SCHEMES
+
+
+def _sanitize_body_html(value: str) -> str:
+    soup = BeautifulSoup(value or "", "html.parser")
+
+    for comment in soup.find_all(string=lambda item: isinstance(item, Comment)):
+        comment.extract()
+
+    for tag in list(soup.find_all(True)):
+        name = (tag.name or "").lower()
+        if name in _DANGEROUS_TAGS:
+            tag.decompose()
+            continue
+        if name not in _ALLOWED_TAGS:
+            tag.unwrap()
+            continue
+
+        allowed_attrs = _GLOBAL_ATTRS | _TAG_ATTRS.get(name, set())
+        for attr in list(tag.attrs):
+            if attr.lower() not in allowed_attrs:
+                del tag.attrs[attr]
+
+        if tag.has_attr("href") and not _is_safe_href(str(tag["href"])):
+            del tag.attrs["href"]
+        if tag.has_attr("src") and not _is_safe_src(str(tag["src"])):
+            del tag.attrs["src"]
+
+        if name == "a" and tag.has_attr("target"):
+            tag["rel"] = "noopener noreferrer"
+        if name == "img":
+            tag["loading"] = tag.get("loading") or "lazy"
+
+    return str(soup)
 
 
 def _body_image_attachments(attachments: list[dict]) -> tuple[dict[str, dict], list[dict]]:
@@ -71,6 +156,7 @@ def _body_image_attachments(attachments: list[dict]) -> tuple[dict[str, dict], l
         name = attachment.get("name") or ""
         if url:
             by_url[url] = attachment
+            by_url[html.unescape(url)] = attachment
         elif "_inline_img_" in name or "inline_img_" in name:
             inline_images.append(attachment)
 
@@ -86,11 +172,10 @@ def _rewrite_body_image_sources(
     used_file_keys: set[str] = set()
     body_images: list[dict] = []
 
-    def replace(match: re.Match) -> str:
-        nonlocal inline_index
+    soup = BeautifulSoup(body_html or "", "html.parser")
 
-        prefix, quote, src, suffix = match.groups()
-        src = (src or "").strip()
+    for image in soup.find_all("img"):
+        src = (image.get("src") or "").strip()
         attachment = None
 
         if src.startswith("data:image/"):
@@ -98,10 +183,10 @@ def _rewrite_body_image_sources(
                 attachment = inline_images[inline_index]
                 inline_index += 1
         else:
-            attachment = by_url.get(src)
+            attachment = by_url.get(src) or by_url.get(html.unescape(src))
 
         if not attachment:
-            return match.group(0)
+            continue
 
         local_path = attachment["local_path"]
         file_key = attachment.get("file_key") or attachment.get("name") or local_path
@@ -116,9 +201,16 @@ def _rewrite_body_image_sources(
                 "file_size": attachment.get("file_size"),
             }
         )
-        return f'{prefix}{quote}{html.escape(local_path, quote=True)}{suffix}'
+        image["src"] = local_path
+        image.attrs.pop("srcset", None)
+        image.attrs.pop("sizes", None)
 
-    return _IMG_SRC_RE.sub(replace, body_html or ""), body_images, used_file_keys
+    return str(soup), body_images, used_file_keys
+
+
+def _count_tables(content_html: str) -> int:
+    soup = BeautifulSoup(content_html or "", "html.parser")
+    return len(soup.find_all("table"))
 
 
 def _image_attachment_gallery(
@@ -175,8 +267,8 @@ def build_content_payload(body_html: str, attachments: list[dict] | None) -> dic
       - content_assets: image/file metadata for API consumers
       - content_stats: quick counts for importer/tests
     """
-    attachments = attachments or []
-    safe_body_html = _strip_unsafe_html(body_html or "")
+    attachments = [item for item in (attachments or []) if isinstance(item, dict)]
+    safe_body_html = _sanitize_body_html(body_html or "")
     rewritten_html, body_images, used_file_keys = _rewrite_body_image_sources(
         safe_body_html,
         attachments,
@@ -207,7 +299,7 @@ def build_content_payload(body_html: str, attachments: list[dict] | None) -> dic
         "content_stats": {
             "image_count": len(images),
             "file_count": len(downloadable_files),
-            "table_count": len(re.findall(r"<\s*table\b", content_html, re.IGNORECASE)),
+            "table_count": _count_tables(content_html),
         },
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 
 playwright>=1.42
 httpx>=0.27
+beautifulsoup4>=4.12
 apscheduler>=3.10
 pdfplumber>=0.10
 olefile>=0.47

--- a/scripts/re_extract.py
+++ b/scripts/re_extract.py
@@ -74,8 +74,9 @@ def re_extract(
 
         body_text = data.get("body_text") or ""
         body_html = data.get("body_html") or ""
-        attachments = data.get("attachments") or []
-        has_att_text = any(a.get("extracted_text") for a in attachments)
+        raw_attachments = data.get("attachments") or []
+        attachments = raw_attachments if isinstance(raw_attachments, list) else []
+        has_att_text = any(a.get("extracted_text") for a in attachments if isinstance(a, dict))
 
         if wants_key_info and not body_text and not has_att_text:
             skipped += 1

--- a/scripts/re_extract.py
+++ b/scripts/re_extract.py
@@ -1,16 +1,10 @@
 """
-CamPost Pipeline — re-extract 배치 스크립트
+Rebuild derived raw JSON fields.
 
-/data/raw/*.json을 순회해 현재 extractor로 deadline/target/apply_method를 재추출하고
-변경된 파일만 덮어써서 Importer가 DB를 자동 갱신하게 합니다.
-
-사용법:
-  python scripts/re_extract.py                          # 전체 실행 (AI 포함)
-  python scripts/re_extract.py --no-ai                  # regex만 (빠름, API 키 불필요)
-  python scripts/re_extract.py --only-null              # null인 필드만 채움 (기존 값 보존)
-  python scripts/re_extract.py --dry-run                # 변경 예정 내용만 출력 (저장 안 함)
-  python scripts/re_extract.py --source SW              # 특정 소스만
-  python scripts/re_extract.py --no-ai --only-null      # 안전 모드: regex로 null만 채움
+Examples:
+  python scripts/re_extract.py --no-ai --source SW --fields deadline
+  python scripts/re_extract.py --source SW --fields content_html,content_assets,content_stats
+  python scripts/re_extract.py --dry-run --source SW --fields content_html,content_assets,content_stats
 """
 
 import argparse
@@ -21,7 +15,18 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from crawler.config import GEMINI_API_KEY, GEMINI_MODEL, OUTPUT_DIR
+from crawler.content import build_content_payload
 from crawler.extractor import extract_key_info_with_ai
+
+KEY_INFO_FIELDS = {"deadline", "target", "apply_method"}
+CONTENT_FIELDS = {"content_html", "content_assets", "content_stats"}
+ALLOWED_FIELDS = KEY_INFO_FIELDS | CONTENT_FIELDS
+
+
+def _preview(value: object, limit: int = 80) -> str:
+    text = str(value)[:limit]
+    encoding = sys.stdout.encoding or "utf-8"
+    return text.encode(encoding, errors="backslashreplace").decode(encoding)
 
 
 def re_extract(
@@ -34,25 +39,25 @@ def re_extract(
     raw_dir = Path(OUTPUT_DIR) / "raw"
 
     if not raw_dir.exists():
-        print(f"[오류] raw 디렉토리가 없습니다: {raw_dir}")
+        print(f"[error] raw directory does not exist: {raw_dir}")
         sys.exit(1)
 
     files = sorted(raw_dir.glob("*.json"))
-
     if source_filter:
         prefix = source_filter.upper() + "_"
         files = [f for f in files if f.stem.startswith(prefix)]
 
     api_key = "" if no_ai else GEMINI_API_KEY
     model = GEMINI_MODEL
-    total = len(files)
+    wants_key_info = bool(fields & KEY_INFO_FIELDS)
+    wants_content = bool(fields & CONTENT_FIELDS)
 
     print(
-        f"[re-extract] 대상: {total}개 | AI: {'OFF' if no_ai else f'ON ({model})'} | "
+        f"[re-extract] targets: {len(files)} | AI: {'OFF' if no_ai else f'ON ({model})'} | "
         f"only-null: {only_null} | dry-run: {dry_run} | fields: {','.join(sorted(fields))}"
     )
     if source_filter:
-        print(f"             소스 필터: {source_filter.upper()}")
+        print(f"             source: {source_filter.upper()}")
     print("-" * 60)
 
     updated = 0
@@ -62,114 +67,103 @@ def re_extract(
     for i, path in enumerate(files, 1):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except Exception as e:
-            print(f"[{i}/{total}] {path.name} 읽기 실패: {e}")
+        except Exception as exc:
+            print(f"[{i}/{len(files)}] {path.name} read failed: {exc}")
             errors += 1
             continue
 
         body_text = data.get("body_text") or ""
+        body_html = data.get("body_html") or ""
         attachments = data.get("attachments") or []
-
-        # 본문도 첨부파일 텍스트도 없으면 스킵
         has_att_text = any(a.get("extracted_text") for a in attachments)
-        if not body_text and not has_att_text:
+
+        if wants_key_info and not body_text and not has_att_text:
             skipped += 1
             continue
 
-        try:
-            result = extract_key_info_with_ai(
-                body_text,
-                attachments,
-                api_key,
-                model,
-                title=data.get("title") or "",
-                notice_date=data.get("date") or "",
-            )
-        except Exception as e:
-            print(f"[{i}/{total}] {path.stem} 추출 실패: {e}")
-            errors += 1
-            continue
+        old: dict = {}
+        result: dict = {}
 
-        old = {
-            "deadline":     data.get("deadline"),
-            "target":       data.get("target"),
-            "apply_method": data.get("apply_method"),
-        }
+        if wants_key_info:
+            try:
+                extracted = extract_key_info_with_ai(
+                    body_text,
+                    attachments,
+                    api_key,
+                    model,
+                    title=data.get("title") or "",
+                    notice_date=data.get("date") or "",
+                )
+            except Exception as exc:
+                print(f"[{i}/{len(files)}] {path.stem} extraction failed: {exc}")
+                errors += 1
+                continue
 
-        result = {
-            k: result[k] if k in fields else old[k]
-            for k in old
-        }
+            for key in KEY_INFO_FIELDS:
+                old[key] = data.get(key)
+                result[key] = extracted[key] if key in fields else old[key]
 
-        # --only-null: 기존 값이 있는 필드는 건드리지 않음
+        if wants_content:
+            content_payload = build_content_payload(body_html, attachments)
+            for key in CONTENT_FIELDS:
+                old[key] = data.get(key)
+                result[key] = content_payload[key] if key in fields else old[key]
+
         if only_null:
-            result = {
-                k: result[k] if old[k] is None else old[k]
-                for k in old
-            }
+            result = {key: value if old[key] is None else old[key] for key, value in result.items()}
 
-        changed = {k for k in old if old[k] != result[k]}
-
+        changed = {key for key in old if old[key] != result[key]}
         if not changed:
             skipped += 1
             continue
 
         diff_str = " | ".join(
-            f"{k}: {str(old[k])!r} → {str(result[k])!r}" for k in sorted(changed)
+            f"{key}: {_preview(old[key])!r} -> {_preview(result[key])!r}"
+            for key in sorted(changed)
         )
-        print(f"[{i}/{total}] {path.stem}  {diff_str}")
+        print(f"[{i}/{len(files)}] {path.stem}  {diff_str}")
 
         if not dry_run:
-            data["deadline"]     = result["deadline"]
-            data["target"]       = result["target"]
-            data["apply_method"] = result["apply_method"]
-            path.write_text(
-                json.dumps(data, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
+            for key, value in result.items():
+                data[key] = value
+            path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
         updated += 1
 
     print("-" * 60)
-    action = "변경 예정" if dry_run else "업데이트 완료"
-    print(f"[re-extract] {action}: {updated}개 | 변경 없음: {skipped}개 | 오류: {errors}개")
+    action = "would update" if dry_run else "updated"
+    print(f"[re-extract] {action}: {updated} | unchanged: {skipped} | errors: {errors}")
     if not dry_run and updated > 0:
-        print("  → Importer가 30초 내 DB 자동 반영합니다.")
+        print("  Importer should pick up the changed raw JSON files on its next cycle.")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="extractor 재실행 배치 스크립트")
+    parser = argparse.ArgumentParser(description="Rebuild derived raw JSON fields.")
+    parser.add_argument("--dry-run", action="store_true", help="print changes without writing files")
+    parser.add_argument("--no-ai", action="store_true", help="disable AI extraction for key info fields")
     parser.add_argument(
-        "--dry-run", action="store_true",
-        help="실제 저장 없이 변경 내용만 출력",
+        "--only-null",
+        action="store_true",
+        help="only fill fields whose current value is null",
     )
-    parser.add_argument(
-        "--no-ai", action="store_true",
-        help="AI 호출 없이 regex만 사용 (빠름, API 쿼터 절약)",
-    )
-    parser.add_argument(
-        "--only-null", action="store_true",
-        help="null인 필드만 채움 (기존 값이 있으면 건드리지 않음, 안전 모드)",
-    )
-    parser.add_argument(
-        "--source",
-        help="특정 소스 코드만 처리 (예: SW, ACE, MOBILE)",
-    )
+    parser.add_argument("--source", help="process one source code only, e.g. SW")
     parser.add_argument(
         "--fields",
         default="deadline,target,apply_method",
-        help="갱신할 필드 목록(쉼표 구분). 예: deadline",
+        help=(
+            "comma-separated fields to update. "
+            "Allowed: deadline,target,apply_method,content_html,content_assets,content_stats"
+        ),
     )
     args = parser.parse_args()
 
-    allowed_fields = {"deadline", "target", "apply_method"}
     selected_fields = {field.strip() for field in args.fields.split(",") if field.strip()}
-    unknown_fields = selected_fields - allowed_fields
+    unknown_fields = selected_fields - ALLOWED_FIELDS
     if unknown_fields:
-        print(f"[오류] 알 수 없는 fields 값: {', '.join(sorted(unknown_fields))}")
+        print(f"[error] unknown fields: {', '.join(sorted(unknown_fields))}")
         sys.exit(1)
     if not selected_fields:
-        print("[오류] fields 값이 비어 있습니다.")
+        print("[error] fields cannot be empty")
         sys.exit(1)
 
     re_extract(

--- a/scripts/recover_article.py
+++ b/scripts/recover_article.py
@@ -1,11 +1,14 @@
 """
-특정 article_id를 직접 크롤링해서 raw JSON 복구하는 스크립트.
-사용법: python scripts/recover_article.py <SOURCE_CODE> <RAW_ID>
-예시:   python scripts/recover_article.py SW 173021
+Recover one raw JSON notice by crawling a detail page directly.
+
+Usage:
+  python scripts/recover_article.py <SOURCE_CODE> <RAW_ID>
+Example:
+  python scripts/recover_article.py SW 173021
 """
 
 import asyncio
-import glob as _glob
+import glob
 import hashlib
 import json
 import sys
@@ -14,24 +17,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from crawler.config import (
-    GEMINI_API_KEY,
-    GEMINI_MODEL,
-    OUTPUT_DIR,
-    SOURCES,
-)
+from playwright.async_api import async_playwright
+
+from crawler.config import GEMINI_API_KEY, GEMINI_MODEL, OUTPUT_DIR, SOURCES
+from crawler.content import build_content_payload
 from crawler.extractor import extract_key_info_with_ai
+from crawler.file_handler import extract_external_images, extract_inline_images, process_attachments
 
 
-async def recover(code: str, raw_id: str) -> None:
-    source = next((s for s in SOURCES if s["code"] == code), None)
-    if source is None:
-        print(f"[오류] 소스 코드 '{code}' 를 찾을 수 없습니다.")
-        sys.exit(1)
-
-    article_id = f"{code}_{raw_id}"
-    base_url = source["base_url"]
-    detail_url = (
+def _detail_url(base_url: str, raw_id: str) -> str:
+    return (
         f"{base_url}"
         "?p_p_id=dku_bbs_web_BbsPortlet"
         "&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view"
@@ -39,17 +34,30 @@ async def recover(code: str, raw_id: str) -> None:
         f"&_dku_bbs_web_BbsPortlet_bbsMessageId={raw_id}"
     )
 
-    shells = _glob.glob(
-        "/root/.cache/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell"
+
+def _find_headless_shell() -> str | None:
+    shells = glob.glob(
+        "/root/.cache/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-linux64/chrome-headless-shell"
     )
+    return shells[0] if shells else None
 
-    from playwright.async_api import async_playwright
 
-    print(f"[1/4] 브라우저 실행 → {detail_url}")
+async def recover(code: str, raw_id: str) -> None:
+    code = code.upper()
+    source = next((item for item in SOURCES if item["code"] == code), None)
+    if source is None:
+        print(f"[error] unknown source code: {code}")
+        sys.exit(1)
+
+    article_id = f"{code}_{raw_id}"
+    detail_url = _detail_url(source["base_url"], raw_id)
+
+    print(f"[1/4] crawling {detail_url}")
     async with async_playwright() as pw:
         browser = await pw.chromium.launch(
             headless=True,
-            executable_path=shells[0] if shells else None,
+            executable_path=_find_headless_shell(),
             args=[
                 "--no-sandbox",
                 "--disable-setuid-sandbox",
@@ -61,64 +69,62 @@ async def recover(code: str, raw_id: str) -> None:
         page = await browser.new_page()
         await page.goto(detail_url, wait_until="networkidle", timeout=30000)
 
-        # 제목 추출
         title = ""
-        for sel in [
+        for selector in [
             "table[summary*='게시판'] tr:first-child td",
             "table[summary*='게시판'] th",
             ".dku-bbs-view-title",
             ".item-title h4",
         ]:
-            el = await page.query_selector(sel)
-            if el:
-                t = (await el.inner_text()).strip()
-                if len(t) > 5:
-                    title = t
-                    break
+            element = await page.query_selector(selector)
+            if not element:
+                continue
+            text = (await element.inner_text()).strip()
+            if len(text) > 5:
+                title = text
+                break
 
-        # 작성자/날짜/조회수 추출 (두 번째 행)
         author, date_str, views = "", "", "0"
-        meta_els = await page.query_selector_all(
-            "table[summary*='게시판'] tr:nth-child(2) td"
-        )
-        if len(meta_els) >= 3:
-            author = (await meta_els[0].inner_text()).strip()
-            date_str = (await meta_els[1].inner_text()).strip()
-            views = (await meta_els[2].inner_text()).strip()
+        meta_elements = await page.query_selector_all("table[summary*='게시판'] tr:nth-child(2) td")
+        if len(meta_elements) >= 3:
+            author = (await meta_elements[0].inner_text()).strip()
+            date_str = (await meta_elements[1].inner_text()).strip()
+            views = (await meta_elements[2].inner_text()).strip()
 
-        # 본문
-        body_el = await page.query_selector("td.r_cont")
-        body_text = (await body_el.inner_text()).strip() if body_el else ""
-        body_html = (await body_el.inner_html()).strip() if body_el else ""
+        body_element = await page.query_selector("td.r_cont")
+        body_text = (await body_element.inner_text()).strip() if body_element else ""
+        body_html = (await body_element.inner_html()).strip() if body_element else ""
 
-        # 첨부파일
-        att_els = await page.query_selector_all('a[href*="download=true"]')
-        attachments = []
-        for att in att_els:
-            href = await att.get_attribute("href") or ""
-            name = (await att.inner_text()).strip()
-            attachments.append(
+        attachment_links = await page.query_selector_all('a[href*="download=true"]')
+        raw_attachments = []
+        for link in attachment_links:
+            href = await link.get_attribute("href") or ""
+            name = (await link.inner_text()).strip()
+            raw_attachments.append(
                 {
                     "url": href,
                     "name": name,
-                    "file_key": "",
-                    "download_ok": False,
-                    "extracted_text": "",
-                    "parser": "none",
-                    "parse_ok": False,
+                    "ext": name.split(".")[-1].lower() if "." in name else "",
                 }
             )
 
         await browser.close()
 
     if not title:
-        print("[경고] 제목 추출 실패 — 임시 제목 사용")
-        title = f"[복구] {article_id}"
+        print("[warn] title extraction failed; using fallback title")
+        title = f"[recovered] {article_id}"
 
-    print(f"[2/4] 추출 완료 — 제목: {title[:60]} | 본문: {len(body_text)}자 | 첨부: {len(attachments)}개")
+    attachments = await process_attachments(raw_attachments, article_id)
+    attachments.extend(extract_inline_images(body_html, article_id))
+    attachments.extend(await extract_external_images(body_html, article_id))
+    content_payload = build_content_payload(body_html, attachments)
 
-    # AI 추출
-    print(f"[3/4] AI 추출 중 (모델: {GEMINI_MODEL}) ...")
+    print(
+        f"[2/4] extracted title={title[:60]!r} | body={len(body_text)} chars | "
+        f"attachments={len(attachments)}"
+    )
+
+    print(f"[3/4] extracting key info with {GEMINI_MODEL}")
     extracted = extract_key_info_with_ai(
         body_text,
         attachments,
@@ -133,10 +139,8 @@ async def recover(code: str, raw_id: str) -> None:
         f"apply_method={extracted['apply_method']}"
     )
 
-    # raw JSON 저장
     now = datetime.now(timezone.utc)
-    hash_val = hashlib.sha256(f"{article_id}:{title}".encode()).hexdigest()
-
+    hash_val = hashlib.sha256(f"{article_id}:{title}".encode("utf-8")).hexdigest()
     notice = {
         "article_id": article_id,
         "raw_id": raw_id,
@@ -149,6 +153,7 @@ async def recover(code: str, raw_id: str) -> None:
         "has_attachment": len(attachments) > 0,
         "body_text": body_text,
         "body_html": body_html,
+        **content_payload,
         "category": "",
         "source_id": source["id"],
         "source_url": detail_url,
@@ -164,21 +169,20 @@ async def recover(code: str, raw_id: str) -> None:
     raw_dir = Path(OUTPUT_DIR) / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
     out_path = raw_dir / f"{article_id}.json"
-    out_path.write_text(json.dumps(notice, ensure_ascii=False, indent=2))
+    out_path.write_text(json.dumps(notice, ensure_ascii=False, indent=2), encoding="utf-8")
 
-    # seen_hashes 갱신
-    hf = Path(OUTPUT_DIR) / "seen_hashes.json"
-    hashes = json.loads(hf.read_text()) if hf.exists() else []
+    hashes_path = Path(OUTPUT_DIR) / "seen_hashes.json"
+    hashes = json.loads(hashes_path.read_text(encoding="utf-8")) if hashes_path.exists() else []
     if hash_val not in hashes:
         hashes.append(hash_val)
-        hf.write_text(json.dumps(hashes, indent=2))
+        hashes_path.write_text(json.dumps(hashes, ensure_ascii=False, indent=2), encoding="utf-8")
 
-    print(f"[4/4] 저장 완료 → {out_path}")
-    print("      Spring Boot Importer가 30초 내 자동 적재합니다.")
+    print(f"[4/4] saved {out_path}")
+    print("      Importer should pick up the changed raw JSON file on its next cycle.")
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print("사용법: python scripts/recover_article.py <SOURCE_CODE> <RAW_ID>")
+        print("Usage: python scripts/recover_article.py <SOURCE_CODE> <RAW_ID>")
         sys.exit(1)
     asyncio.run(recover(sys.argv[1], sys.argv[2]))

--- a/scripts/recover_article.py
+++ b/scripts/recover_article.py
@@ -98,7 +98,7 @@ async def recover(code: str, raw_id: str) -> None:
         attachment_links = await page.query_selector_all('a[href*="download=true"]')
         raw_attachments = []
         for link in attachment_links:
-            href = await link.get_attribute("href") or ""
+            href = await link.evaluate("(el) => el.href") or ""
             name = (await link.inner_text()).strip()
             raw_attachments.append(
                 {

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,78 @@
+import unittest
+
+from crawler.content import build_content_payload
+
+
+class ContentTests(unittest.TestCase):
+    def test_rewrites_downloaded_external_image_src(self):
+        payload = build_content_payload(
+            '<p><img src="https://example.com/poster.png"></p>',
+            [
+                {
+                    "name": "poster.png",
+                    "url": "https://example.com/poster.png",
+                    "ext": "png",
+                    "file_key": "SW_1_poster.png",
+                    "local_path": "files/SW_1_poster.png",
+                    "mime_type": "image/png",
+                    "file_size": 100,
+                    "download_ok": True,
+                }
+            ],
+        )
+
+        self.assertIn('src="files/SW_1_poster.png"', payload["content_html"])
+        self.assertEqual(payload["content_stats"]["image_count"], 1)
+        self.assertEqual(payload["content_assets"]["images"][0]["src"], "files/SW_1_poster.png")
+
+    def test_rewrites_inline_image_src_by_order(self):
+        payload = build_content_payload(
+            '<img src="data:image/png;base64,AAA=">',
+            [
+                {
+                    "name": "SW_1_inline_img_0.png",
+                    "url": "",
+                    "ext": "png",
+                    "file_key": "SW_1_inline_img_0.png",
+                    "local_path": "files/SW_1_inline_img_0.png",
+                    "mime_type": "image/png",
+                    "download_ok": True,
+                }
+            ],
+        )
+
+        self.assertIn('src="files/SW_1_inline_img_0.png"', payload["content_html"])
+        self.assertNotIn("data:image", payload["content_html"])
+
+    def test_appends_unembedded_image_attachment_gallery(self):
+        payload = build_content_payload(
+            "<p>Body</p>",
+            [
+                {
+                    "name": "poster.png",
+                    "url": "https://example.com/download=true",
+                    "ext": "png",
+                    "file_key": "SW_1_poster.png",
+                    "local_path": "files/SW_1_poster.png",
+                    "mime_type": "image/png",
+                    "download_ok": True,
+                }
+            ],
+        )
+
+        self.assertIn("notice-content-image-attachments", payload["content_html"])
+        self.assertIn('src="files/SW_1_poster.png"', payload["content_html"])
+        self.assertEqual(payload["content_stats"]["image_count"], 1)
+
+    def test_counts_tables_and_strips_script(self):
+        payload = build_content_payload(
+            '<script>alert(1)</script><table><tr><td>A</td></tr></table>',
+            [],
+        )
+
+        self.assertNotIn("<script", payload["content_html"].lower())
+        self.assertEqual(payload["content_stats"]["table_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -25,6 +25,28 @@ class ContentTests(unittest.TestCase):
         self.assertEqual(payload["content_stats"]["image_count"], 1)
         self.assertEqual(payload["content_assets"]["images"][0]["src"], "files/SW_1_poster.png")
 
+    def test_rewrites_unquoted_image_src_and_removes_responsive_sources(self):
+        payload = build_content_payload(
+            '<p><img src=https://example.com/poster.png '
+            'srcset="https://example.com/poster-2x.png 2x" sizes="100vw"></p>',
+            [
+                {
+                    "name": "poster.png",
+                    "url": "https://example.com/poster.png",
+                    "ext": "png",
+                    "file_key": "SW_1_poster.png",
+                    "local_path": "files/SW_1_poster.png",
+                    "mime_type": "image/png",
+                    "file_size": 100,
+                    "download_ok": True,
+                }
+            ],
+        )
+
+        self.assertIn('src="files/SW_1_poster.png"', payload["content_html"])
+        self.assertNotIn("srcset", payload["content_html"])
+        self.assertNotIn("sizes", payload["content_html"])
+
     def test_rewrites_inline_image_src_by_order(self):
         payload = build_content_payload(
             '<img src="data:image/png;base64,AAA=">',
@@ -72,6 +94,27 @@ class ContentTests(unittest.TestCase):
 
         self.assertNotIn("<script", payload["content_html"].lower())
         self.assertEqual(payload["content_stats"]["table_count"], 1)
+
+    def test_sanitizes_javascript_urls_events_and_comments(self):
+        payload = build_content_payload(
+            '<!-- <table></table> -->'
+            '<a href=javascript:alert(1) onclick="alert(2)">bad</a>'
+            '<img src=javascript:alert(3) onerror="alert(4)">',
+            [],
+        )
+
+        html = payload["content_html"].lower()
+        self.assertNotIn("javascript:", html)
+        self.assertNotIn("onclick", html)
+        self.assertNotIn("onerror", html)
+        self.assertNotIn("<!--", html)
+        self.assertEqual(payload["content_stats"]["table_count"], 0)
+
+    def test_ignores_non_list_attachments(self):
+        payload = build_content_payload("<p>Body</p>", {"bad": "shape"})
+
+        self.assertEqual(payload["content_assets"]["images"], [])
+        self.assertEqual(payload["content_assets"]["files"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #15 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

크롤러/Pipeline 변경

  - 공고 원본 body_html은 그대로 보존
  - 렌더링용 신규 필드 추가:
      - content_html
      - content_assets
      - content_stats

  표 처리

  - 본문 HTML 안에 있는 <table> 태그를 제거하지 않고 content_html에 그대로 보존
  - content_stats.table_count에 본문 내 표 개수 기록
  - 첨부파일 안의 표를 HTML 표로 변환하는 작업은 아님

  이미지 처리

  - 본문 안의 외부 이미지 URL을 다운로드된 로컬 경로로 치환
      - 예: 외부 <img src="https://..."> → files/...
  - 본문 안의 base64 인라인 이미지를 파일로 저장하고 files/... 경로로 치환
  - 본문에 직접 포함되지 않은 이미지 첨부파일은 content_html 하단 이미지 섹션에 추가
  - 이미지 메타데이터를 content_assets.images에 저장

  첨부파일 처리

  - 이미지가 아닌 다운로드 파일은 content_assets.files에 저장
  - content_stats.file_count에 파일 개수 기록

  보안/정리 처리

  - script, iframe, object, embed, 이벤트 핸들러 속성, javascript: URL 등 위험 요소 일부 제거
  - frontend에서 바로 렌더링할 수 있는 형태의 HTML을 생성

  적용/검증

  - SW 공고 27건에 대해 백필 완료
  - 결과:
      - content_html 생성: 27건
      - 이미지 총 15개
      - 표 총 2개
      - 오류 0건
  - 테스트:
      - python -m unittest discover -s tests -p "test_*.py" 통과, 29 tests OK

요약: 본문 내 표를 유지하고, 본문/첨부 이미지를 실제 렌더링 가능한 HTML과 메타데이터로 정리하는 pipeline 개선

ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ

현재 backend/frontend에는 새 필드를 DB/API/UI까지 흘려보내고 렌더링하는 작업이 필요함


 Backend 작업

  - raw JSON의 신규 필드 수집:
      - content_html
      - content_assets
      - content_stats
  - DB 모델/테이블에 저장하거나, 기존 raw payload에서 API 응답으로 매핑
  - 공고 상세 API 응답에 신규 필드 노출
  - files/... 경로를 프론트에서 접근 가능한 URL로 변환하거나, 파일 제공 엔드포인트 기준을 명확히 제공
      - 예: files/abc.png → /api/files/abc.png 또는 정적 파일 URL
  - HTML 렌더링 보안 기준 확인
      - crawler에서 1차 sanitize는 했지만, backend/API 경계에서 허용 필드와 타입 검증 필요
  - 기존 plain text 필드와의 호환성 유지
      - bodyText는 fallback으로 남기고, 상세 화면은 content_html 우선 사용 가능하게 제공

  Frontend 작업

  - 공고 상세 화면에서 기존 bodyText 대신 content_html 우선 렌더링
      - content_html이 없으면 기존 bodyText fallback
  - HTML 렌더링 방식 추가
      - React라면 dangerouslySetInnerHTML 사용 가능하지만, 신뢰 경계와 sanitize 정책을 명확히 해야 함
  - content_html 안의 이미지 src="files/..."를 실제 접근 가능한 URL로 변환
  - 본문 표 스타일 추가
      - 모바일 가로 스크롤
      - border/cell padding
      - 긴 텍스트 줄바꿈
  - 이미지 스타일 추가
      - 본문 이미지 최대 너비 100%
      - lazy loading 유지
      - 첨부 이미지 섹션/캡션 스타일
  - 깨진 이미지 처리
      - 로딩 실패 시 숨김 또는 대체 표시
  - 기존 상세 화면의 첨부파일 목록과 중복 표시 여부 결정
      - 이미지 첨부파일은 content_html 하단에 표시될 수 있으므로, 첨부 목록에서도 또 보일지 정책 필요



## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * HTML 콘텐츠에서 불안전한 스크립트 및 속성 제거
  * 다운로드된 첨부파일 기반 이미지 링크 자동 재작성
  * 콘텐츠 메타데이터(이미지/파일 수, 테이블 수) 자동 생성

* **테스트**
  * 콘텐츠 처리 및 이미지 변환 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->