### PR TITLE
Feat(#19): 첨부파일 중복 다운로드 방지 구현

### DIFF
--- a/crawler/file_handler.py
+++ b/crawler/file_handler.py
@@ -44,6 +44,10 @@ def _compute_checksum(path: Path) -> str:
     return sha256.hexdigest()
 
 
+def _is_reusable_download(path: Path) -> bool:
+    return path.is_file() and path.stat().st_size > 0
+
+
 def _get_mime_type(filename: str) -> str:
     mime, _ = mimetypes.guess_type(filename)
     return mime or "application/octet-stream"
@@ -389,7 +393,13 @@ async def process_attachments(attachments: list[dict], article_id: str) -> list[
         filename = _safe_filename(article_id, att["name"])
         save_path = FILES_DIR / filename
 
-        download_ok = await download_file(att["url"], save_path)
+        download_cached = False
+        if _is_reusable_download(save_path):
+            download_ok = True
+            download_cached = True
+            log.debug(f"Download cache hit: {save_path.name} ({save_path.stat().st_size:,} bytes)")
+        else:
+            download_ok = await download_file(att["url"], save_path)
 
         extracted_text = ""
         parser = "none"
@@ -426,6 +436,7 @@ async def process_attachments(attachments: list[dict], article_id: str) -> list[
                 "extracted_text": extracted_text,
                 "extracted_chars": len(extracted_text),
                 "download_ok": download_ok,
+                "download_cached": download_cached,
                 "parser": parser,
                 "parse_quality": parse_quality,
                 "parse_ok": parse_ok,

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -2,8 +2,10 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
-from crawler.file_handler import extract_text
+from crawler import file_handler
+from crawler.file_handler import extract_text, process_attachments
 
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -16,32 +18,96 @@ def _docx_xml(body: str) -> str:
     )
 
 
+def _write_docx(path: Path, document_body: str, header_body: str | None = None) -> None:
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("word/document.xml", _docx_xml(document_body))
+        if header_body is not None:
+            z.writestr("word/header1.xml", _docx_xml(header_body))
+
+
 class FileHandlerTests(unittest.TestCase):
     def test_extracts_docx_paragraph_table_and_header_text(self):
-        document_xml = _docx_xml(
-            "<w:p><w:r><w:t>첫 문단</w:t></w:r></w:p>"
-            "<w:tbl><w:tr>"
-            "<w:tc><w:p><w:r><w:t>표 셀 A</w:t></w:r></w:p></w:tc>"
-            "<w:tc><w:p><w:r><w:t>표 셀 B</w:t></w:r></w:p></w:tc>"
-            "</w:tr></w:tbl>"
-            "<w:p><w:r><w:t>탭</w:t><w:tab/><w:t>줄바꿈</w:t><w:br/><w:t>다음</w:t></w:r></w:p>"
-        )
-        header_xml = _docx_xml("<w:p><w:r><w:t>머리말</w:t></w:r></w:p>")
-
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "sample.docx"
-            with zipfile.ZipFile(path, "w") as z:
-                z.writestr("word/document.xml", document_xml)
-                z.writestr("word/header1.xml", header_xml)
+            _write_docx(
+                path,
+                "<w:p><w:r><w:t>First paragraph</w:t></w:r></w:p>"
+                "<w:tbl><w:tr>"
+                "<w:tc><w:p><w:r><w:t>Cell A</w:t></w:r></w:p></w:tc>"
+                "<w:tc><w:p><w:r><w:t>Cell B</w:t></w:r></w:p></w:tc>"
+                "</w:tr></w:tbl>"
+                "<w:p><w:r><w:t>Before</w:t><w:tab/><w:t>After tab</w:t>"
+                "<w:br/><w:t>After break</w:t></w:r></w:p>",
+                "<w:p><w:r><w:t>Header text</w:t></w:r></w:p>",
+            )
 
             text, parser = extract_text(path, "docx")
 
         self.assertEqual(parser, "docx_xml")
-        self.assertIn("첫 문단", text)
-        self.assertIn("표 셀 A", text)
-        self.assertIn("표 셀 B", text)
-        self.assertIn("탭\t줄바꿈\n다음", text)
-        self.assertIn("머리말", text)
+        self.assertIn("First paragraph", text)
+        self.assertIn("Cell A", text)
+        self.assertIn("Cell B", text)
+        self.assertIn("Before\tAfter tab\nAfter break", text)
+        self.assertIn("Header text", text)
+
+
+class AttachmentCacheTests(unittest.IsolatedAsyncioTestCase):
+    async def test_process_attachments_reuses_existing_non_empty_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            cached_path = files_dir / "SW_1_cached.docx"
+            _write_docx(
+                cached_path,
+                "<w:p><w:r><w:t>Cached document text</w:t></w:r></w:p>",
+            )
+
+            with (
+                patch.object(file_handler, "FILES_DIR", files_dir),
+                patch.object(file_handler, "download_file", new=AsyncMock(return_value=True)) as download,
+            ):
+                results = await process_attachments(
+                    [{"name": "cached.docx", "url": "https://example.test/cached.docx", "ext": "docx"}],
+                    "SW_1",
+                )
+
+        download.assert_not_awaited()
+        self.assertEqual(len(results), 1)
+        attachment = results[0]
+        self.assertTrue(attachment["download_ok"])
+        self.assertTrue(attachment["download_cached"])
+        self.assertEqual(attachment["parser"], "docx_xml")
+        self.assertEqual(attachment["parse_quality"], "full")
+        self.assertIn("Cached document text", attachment["extracted_text"])
+        self.assertGreater(attachment["file_size"], 0)
+        self.assertRegex(attachment["checksum"], r"^[0-9a-f]{64}$")
+
+    async def test_process_attachments_redownloads_zero_byte_file(self):
+        async def fake_download(_url: str, save_path: Path) -> bool:
+            save_path.write_bytes(b"fresh")
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            cached_path = files_dir / "SW_1_empty.txt"
+            cached_path.write_bytes(b"")
+
+            with (
+                patch.object(file_handler, "FILES_DIR", files_dir),
+                patch.object(file_handler, "download_file", side_effect=fake_download) as download,
+            ):
+                results = await process_attachments(
+                    [{"name": "empty.txt", "url": "https://example.test/empty.txt", "ext": "txt"}],
+                    "SW_1",
+                )
+
+        self.assertEqual(download.await_count, 1)
+        self.assertEqual(len(results), 1)
+        attachment = results[0]
+        self.assertTrue(attachment["download_ok"])
+        self.assertFalse(attachment["download_cached"])
+        self.assertEqual(attachment["file_size"], 5)
+        self.assertEqual(attachment["parser"], "none")
+        self.assertEqual(attachment["parse_quality"], "none")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #19 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

첨부파일의 경우 중복으로 다운로드 하면 안되기에 방지기능 구현

같은 article_id + 같은 첨부파일명
-> 같은 data/files 경로
-> 기존 파일이 있고 0바이트보다 크면
-> 다시 다운로드하지 않고 기존 파일 재사용

그리고 raw attachment에 다음 필드 추가 

"download_cached" : true

새로 다운로드한 경우 ->  "download_cached" : false



## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 첨부파일 다운로드 캐싱 기능 추가로 중복 파일의 반복 다운로드 제거 및 처리 성능 향상

* **테스트**
  * 문서 처리 및 캐시 재사용 시나리오에 대한 테스트 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->