### PR TITLE
Feat(#32): RHWP 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,5 +31,6 @@ GEMINI_MODEL=gemini-2.5-flash
 PDF_CONVERSION_ENABLED=true
 PDF_CONVERSION_TIMEOUT_SECONDS=60
 PDF_PREVIEW_EXTS=hwp,hwpx
-# Optional. Leave empty to auto-detect soffice/libreoffice from PATH.
-LIBREOFFICE_BIN=
+# Optional. Leave empty to auto-detect rhwp and Playwright Chromium/Chrome.
+RHWP_BIN=
+CHROME_BIN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
@@ -10,8 +10,16 @@ RUN apt-get update && apt-get install -y \
     libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
     libxrandr2 libgbm1 libasound2 \
     fontconfig fonts-dejavu-core fonts-liberation fonts-noto-cjk \
-    libreoffice-writer \
     && rm -rf /var/lib/apt/lists/*
+
+ARG RHWP_VERSION=v0.7.10
+RUN curl -L "https://github.com/edwardkim/rhwp/releases/download/${RHWP_VERSION}/rhwp-${RHWP_VERSION}-linux-x86_64.tar.gz" \
+    -o /tmp/rhwp.tar.gz \
+    && mkdir -p /tmp/rhwp \
+    && tar -xzf /tmp/rhwp.tar.gz -C /tmp/rhwp \
+    && find /tmp/rhwp -type f -name rhwp -exec install -m 0755 {} /usr/local/bin/rhwp \; \
+    && test -x /usr/local/bin/rhwp \
+    && rm -rf /tmp/rhwp /tmp/rhwp.tar.gz
 
 # Python 의존성
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12-slim-bookworm
 
 WORKDIR /app
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # 시스템 의존성 (Playwright Chromium)
 RUN apt-get update && apt-get install -y \
@@ -13,13 +14,17 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ARG RHWP_VERSION=v0.7.10
-RUN curl -L "https://github.com/edwardkim/rhwp/releases/download/${RHWP_VERSION}/rhwp-${RHWP_VERSION}-linux-x86_64.tar.gz" \
-    -o /tmp/rhwp.tar.gz \
-    && mkdir -p /tmp/rhwp \
-    && tar -xzf /tmp/rhwp.tar.gz -C /tmp/rhwp \
+RUN set -eux; \
+    archive="rhwp-${RHWP_VERSION}-linux-x86_64.tar.gz"; \
+    curl -L "https://github.com/edwardkim/rhwp/releases/download/${RHWP_VERSION}/${archive}" -o "/tmp/${archive}"; \
+    curl -L "https://github.com/edwardkim/rhwp/releases/download/${RHWP_VERSION}/SHA256SUMS.txt" -o /tmp/SHA256SUMS.txt; \
+    cd /tmp; \
+    grep " ${archive}$" SHA256SUMS.txt | sha256sum -c -; \
+    mkdir -p /tmp/rhwp \
+    && tar -xzf "/tmp/${archive}" -C /tmp/rhwp \
     && find /tmp/rhwp -type f -name rhwp -exec install -m 0755 {} /usr/local/bin/rhwp \; \
     && test -x /usr/local/bin/rhwp \
-    && rm -rf /tmp/rhwp /tmp/rhwp.tar.gz
+    && rm -rf /tmp/rhwp "/tmp/${archive}" /tmp/SHA256SUMS.txt
 
 # Python 의존성
 COPY requirements.txt .
@@ -28,9 +33,16 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Playwright 브라우저 설치
 RUN playwright install chromium
 
-COPY . .
+RUN groupadd --system app \
+    && useradd --system --gid app --create-home app \
+    && mkdir -p /data /ms-playwright \
+    && chown -R app:app /app /data /ms-playwright
+
+COPY --chown=app:app . .
 
 ENV PYTHONUNBUFFERED=1
 ENV OUTPUT_DIR=/data
+
+USER app
 
 CMD ["python", "main.py", "--loop"]

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -134,7 +134,8 @@ PDF_PREVIEW_EXTS = {
 }
 PDF_CONVERSION_ENABLED: bool = os.getenv("PDF_CONVERSION_ENABLED", "true").lower() != "false"
 PDF_CONVERSION_TIMEOUT_SECONDS: int = int(os.getenv("PDF_CONVERSION_TIMEOUT_SECONDS", "60"))
-LIBREOFFICE_BIN: str = os.getenv("LIBREOFFICE_BIN", "").strip()
+RHWP_BIN: str = os.getenv("RHWP_BIN", "").strip()
+CHROME_BIN: str = os.getenv("CHROME_BIN", "").strip()
 
 # ── DB 연결 (crawl_jobs / parse_logs 쓰기 전용) ──────────
 DB_HOST = os.getenv("DB_HOST", "db")

--- a/crawler/file_handler.py
+++ b/crawler/file_handler.py
@@ -8,6 +8,7 @@ HWPX : zipfile + XML 파싱
 
 import asyncio
 import base64
+import errno
 import hashlib
 import logging
 import mimetypes
@@ -15,6 +16,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 import zipfile
 from functools import lru_cache
 from pathlib import Path
@@ -24,12 +26,13 @@ from xml.etree import ElementTree as ET
 import httpx
 
 from .config import (
+    CHROME_BIN,
     EXTRACTABLE_EXTS,
     FILES_DIR,
-    LIBREOFFICE_BIN,
     PDF_CONVERSION_ENABLED,
     PDF_CONVERSION_TIMEOUT_SECONDS,
     PDF_PREVIEW_EXTS,
+    RHWP_BIN,
     USER_AGENT,
 )
 
@@ -78,7 +81,7 @@ def _pdf_preview_success_metadata(path: Path) -> dict:
         "preview_pdf_size": path.stat().st_size,
         "preview_pdf_checksum": _compute_checksum(path),
         "conversion_status": "success",
-        "conversion_engine": "libreoffice",
+        "conversion_engine": "rhwp+chrome",
         "conversion_error": None,
     }
 
@@ -94,26 +97,131 @@ def _is_reusable_pdf_preview(source_path: Path, preview_path: Path) -> bool:
         return False
 
 
+def _replace_file_with_retry(source: Path, target: Path) -> None:
+    last_error: OSError | None = None
+    for _ in range(10):
+        try:
+            source.replace(target)
+            return
+        except OSError as exc:
+            last_error = exc
+            if exc.errno not in {errno.EXDEV, errno.EACCES, errno.EPERM}:
+                raise
+            try:
+                shutil.copy2(source, target)
+                source.unlink(missing_ok=True)
+                return
+            except PermissionError as copy_exc:
+                last_error = copy_exc
+            time.sleep(0.2)
+    if last_error:
+        raise last_error
+
+
 @lru_cache(maxsize=1)
-def _find_libreoffice() -> str | None:
-    if LIBREOFFICE_BIN:
-        configured = Path(LIBREOFFICE_BIN)
+def _find_rhwp() -> str | None:
+    if RHWP_BIN:
+        configured = Path(RHWP_BIN)
         if configured.exists():
             return str(configured)
-        resolved = shutil.which(LIBREOFFICE_BIN)
+        resolved = shutil.which(RHWP_BIN)
         if resolved:
             return resolved
 
-    for candidate in ("soffice", "libreoffice"):
+    return shutil.which("rhwp")
+
+
+@lru_cache(maxsize=1)
+def _find_chrome() -> str | None:
+    if CHROME_BIN:
+        configured = Path(CHROME_BIN)
+        if configured.exists():
+            return str(configured)
+        resolved = shutil.which(CHROME_BIN)
+        if resolved:
+            return resolved
+
+    for candidate in (
+        "chrome",
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "chrome.exe",
+        "msedge.exe",
+    ):
         resolved = shutil.which(candidate)
         if resolved:
             return resolved
+
+    for pattern in (
+        "/root/.cache/ms-playwright/chromium-*/chrome-linux/chrome",
+        "/root/.cache/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell",
+    ):
+        matches = sorted(Path("/").glob(pattern.removeprefix("/")))
+        if matches:
+            return str(matches[0])
+
     return None
+
+
+def _extract_svg_size(svg: str) -> tuple[float, float]:
+    width_match = re.search(r'<svg\b[^>]*\bwidth="([\d.]+)', svg)
+    height_match = re.search(r'<svg\b[^>]*\bheight="([\d.]+)', svg)
+    if width_match and height_match:
+        return float(width_match.group(1)), float(height_match.group(1))
+    viewbox_match = re.search(r'<svg\b[^>]*\bviewBox="[\d.\-]+\s+[\d.\-]+\s+([\d.]+)\s+([\d.]+)"', svg)
+    if viewbox_match:
+        return float(viewbox_match.group(1)), float(viewbox_match.group(2))
+    return 793.7066666666667, 1122.5066666666667
+
+
+def _build_svg_print_html(svg_paths: list[Path], html_path: Path) -> None:
+    first_svg = svg_paths[0].read_text(encoding="utf-8")
+    width, height = _extract_svg_size(first_svg)
+    pages = []
+    for svg_path in svg_paths:
+        svg = svg_path.read_text(encoding="utf-8")
+        pages.append(f'<section class="page">{svg}</section>')
+
+    html = f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@page {{ size: {width}px {height}px; margin: 0; }}
+html, body {{ margin: 0; padding: 0; background: white; }}
+.page {{
+  width: {width}px;
+  height: {height}px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  break-after: page;
+  page-break-after: always;
+}}
+.page:last-child {{
+  break-after: auto;
+  page-break-after: auto;
+}}
+svg {{
+  display: block;
+  width: {width}px;
+  height: {height}px;
+}}
+</style>
+</head>
+<body>
+{chr(10).join(pages)}
+</body>
+</html>
+"""
+    html_path.write_text(html, encoding="utf-8")
 
 
 def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict:
     """
-    Convert an HWP/HWPX attachment to a cached PDF preview with LibreOffice.
+    Convert an HWP/HWPX attachment to a cached PDF preview with RHWP + Chrome.
 
     This is best-effort preview generation. The original attachment remains the
     source of truth, and callers should fall back to extracted text or download
@@ -126,9 +234,13 @@ def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict
     if not PDF_CONVERSION_ENABLED:
         return _default_pdf_preview_metadata("disabled", "PDF conversion is disabled")
 
-    converter = _find_libreoffice()
-    if not converter:
-        return _default_pdf_preview_metadata("unavailable", "LibreOffice executable not found")
+    rhwp = _find_rhwp()
+    if not rhwp:
+        return _default_pdf_preview_metadata("unavailable", "RHWP executable not found")
+
+    chrome = _find_chrome()
+    if not chrome:
+        return _default_pdf_preview_metadata("unavailable", "Chrome/Chromium executable not found")
 
     output_path = _pdf_preview_path(path)
     if not force and _is_reusable_pdf_preview(path, output_path):
@@ -136,49 +248,76 @@ def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict
 
     converted = False
     try:
+        if output_path.exists():
+            output_path.unlink()
+
         with (
-            tempfile.TemporaryDirectory(prefix="campost-lo-") as profile_dir,
-            tempfile.TemporaryDirectory(prefix="campost-pdf-") as output_dir,
+            tempfile.TemporaryDirectory(prefix="campost-rhwp-svg-") as svg_dir,
+            tempfile.TemporaryDirectory(prefix="campost-rhwp-pdf-") as pdf_dir,
         ):
-            profile_uri = Path(profile_dir).resolve().as_uri()
-            completed = subprocess.run(
+            svg_root = Path(svg_dir)
+            pdf_root = Path(pdf_dir)
+            rhwp_completed = subprocess.run(
                 [
-                    converter,
-                    "--headless",
-                    "--nologo",
-                    "--nofirststartwizard",
-                    "--nodefault",
-                    "--nolockcheck",
-                    f"-env:UserInstallation={profile_uri}",
-                    "--convert-to",
-                    "pdf",
-                    "--outdir",
-                    output_dir,
+                    rhwp,
+                    "export-svg",
                     str(path),
+                    "-o",
+                    str(svg_root),
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=PDF_CONVERSION_TIMEOUT_SECONDS,
                 check=False,
             )
-            libreoffice_output_path = Path(output_dir) / path.with_suffix(".pdf").name
+            svg_paths = sorted(svg_root.glob("*.svg"))
+            if rhwp_completed.returncode != 0 or not svg_paths:
+                error = (rhwp_completed.stderr or rhwp_completed.stdout or "RHWP SVG output was not created").strip()
+                return _default_pdf_preview_metadata("failed", error[:500])
+
+            html_path = svg_root / "preview.html"
+            temp_pdf_path = pdf_root / "preview.pdf"
+            _build_svg_print_html(svg_paths, html_path)
+
+            chrome_completed = subprocess.run(
+                [
+                    chrome,
+                    "--headless=new",
+                    "--disable-gpu",
+                    "--no-sandbox",
+                    "--disable-dev-shm-usage",
+                    "--no-pdf-header-footer",
+                    f"--print-to-pdf={temp_pdf_path}",
+                    html_path.resolve().as_uri(),
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=PDF_CONVERSION_TIMEOUT_SECONDS,
+                check=False,
+            )
             if (
-                completed.returncode == 0
-                and libreoffice_output_path.exists()
-                and libreoffice_output_path.stat().st_size > 0
+                chrome_completed.returncode == 0
+                and temp_pdf_path.exists()
+                and temp_pdf_path.stat().st_size > 0
             ):
-                libreoffice_output_path.replace(output_path)
+                _replace_file_with_retry(temp_pdf_path, output_path)
                 converted = True
     except subprocess.TimeoutExpired:
         return _default_pdf_preview_metadata(
             "timeout",
-            f"LibreOffice conversion timed out after {PDF_CONVERSION_TIMEOUT_SECONDS}s",
+            f"RHWP PDF conversion timed out after {PDF_CONVERSION_TIMEOUT_SECONDS}s",
         )
     except (OSError, ValueError) as exc:
         return _default_pdf_preview_metadata("failed", str(exc))
 
-    if completed.returncode != 0 or not converted:
-        error = (completed.stderr or completed.stdout or "PDF output was not created").strip()
+    if not converted:
+        if output_path.exists():
+            output_path.unlink(missing_ok=True)
+        error = (chrome_completed.stderr or chrome_completed.stdout or "PDF output was not created").strip()
         return _default_pdf_preview_metadata("failed", error[:500])
 
     return _pdf_preview_success_metadata(output_path)

--- a/crawler/file_handler.py
+++ b/crawler/file_handler.py
@@ -12,6 +12,7 @@ import errno
 import hashlib
 import logging
 import mimetypes
+import os
 import re
 import shutil
 import subprocess
@@ -45,6 +46,9 @@ logging.getLogger("hwp5").setLevel(logging.WARNING)
 
 _MAX_INLINE_IMAGES = 10
 _MAX_INLINE_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MB
+_A4_WIDTH_PX = 793.7066666666667
+_A4_HEIGHT_PX = 1122.5066666666667
+_SVG_ATTR_NUMBER = r"([-+]?(?:\d+(?:\.\d*)?|\.\d+))"
 
 
 def _safe_filename(article_id: str, name: str) -> str:
@@ -118,11 +122,15 @@ def _replace_file_with_retry(source: Path, target: Path) -> None:
         raise last_error
 
 
+def _is_executable_file(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
 @lru_cache(maxsize=1)
 def _find_rhwp() -> str | None:
     if RHWP_BIN:
         configured = Path(RHWP_BIN)
-        if configured.exists():
+        if _is_executable_file(configured):
             return str(configured)
         resolved = shutil.which(RHWP_BIN)
         if resolved:
@@ -135,7 +143,7 @@ def _find_rhwp() -> str | None:
 def _find_chrome() -> str | None:
     if CHROME_BIN:
         configured = Path(CHROME_BIN)
-        if configured.exists():
+        if _is_executable_file(configured):
             return str(configured)
         resolved = shutil.which(CHROME_BIN)
         if resolved:
@@ -154,26 +162,73 @@ def _find_chrome() -> str | None:
         if resolved:
             return resolved
 
-    for pattern in (
-        "/root/.cache/ms-playwright/chromium-*/chrome-linux/chrome",
-        "/root/.cache/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell",
-    ):
-        matches = sorted(Path("/").glob(pattern.removeprefix("/")))
-        if matches:
-            return str(matches[0])
+    search_roots = []
+    playwright_browsers_path = os.getenv("PLAYWRIGHT_BROWSERS_PATH", "").strip()
+    if playwright_browsers_path and playwright_browsers_path != "0":
+        search_roots.append(Path(playwright_browsers_path))
+    search_roots.append(Path.home() / ".cache" / "ms-playwright")
+
+    for root in search_roots:
+        for pattern in (
+            "chromium-*/chrome-linux/chrome",
+            "chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell",
+        ):
+            matches = sorted(root.glob(pattern))
+            for match in matches:
+                if _is_executable_file(match):
+                    return str(match)
 
     return None
 
 
+def _svg_attr_number(svg: str, attr: str) -> float | None:
+    match = re.search(
+        rf"<svg\b[^>]*\b{attr}\s*=\s*['\"]\s*{_SVG_ATTR_NUMBER}",
+        svg,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    return float(match.group(1))
+
+
+def _chrome_args(
+    chrome: str,
+    temp_pdf_path: Path,
+    html_path: Path,
+    *,
+    headless: str,
+    no_sandbox: bool = False,
+) -> list[str]:
+    args = [
+        chrome,
+        headless,
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        "--no-pdf-header-footer",
+        f"--print-to-pdf={temp_pdf_path}",
+        html_path.resolve().as_uri(),
+    ]
+    if no_sandbox or (hasattr(os, "geteuid") and os.geteuid() == 0):
+        args.insert(3, "--no-sandbox")
+    return args
+
+
 def _extract_svg_size(svg: str) -> tuple[float, float]:
-    width_match = re.search(r'<svg\b[^>]*\bwidth="([\d.]+)', svg)
-    height_match = re.search(r'<svg\b[^>]*\bheight="([\d.]+)', svg)
-    if width_match and height_match:
-        return float(width_match.group(1)), float(height_match.group(1))
-    viewbox_match = re.search(r'<svg\b[^>]*\bviewBox="[\d.\-]+\s+[\d.\-]+\s+([\d.]+)\s+([\d.]+)"', svg)
+    width = _svg_attr_number(svg, "width")
+    height = _svg_attr_number(svg, "height")
+    if width is not None and height is not None:
+        return width, height
+
+    viewbox_match = re.search(
+        rf"<svg\b[^>]*\bviewBox\s*=\s*['\"]\s*{_SVG_ATTR_NUMBER}[,\s]+{_SVG_ATTR_NUMBER}[,\s]+{_SVG_ATTR_NUMBER}[,\s]+{_SVG_ATTR_NUMBER}\s*['\"]",
+        svg,
+        re.IGNORECASE,
+    )
     if viewbox_match:
-        return float(viewbox_match.group(1)), float(viewbox_match.group(2))
-    return 793.7066666666667, 1122.5066666666667
+        return float(viewbox_match.group(3)), float(viewbox_match.group(4))
+
+    return _A4_WIDTH_PX, _A4_HEIGHT_PX
 
 
 def _build_svg_print_html(svg_paths: list[Path], html_path: Path) -> None:
@@ -247,10 +302,8 @@ def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict
         return _pdf_preview_success_metadata(output_path)
 
     converted = False
+    chrome_completed = None
     try:
-        if output_path.exists():
-            output_path.unlink()
-
         with (
             tempfile.TemporaryDirectory(prefix="campost-rhwp-svg-") as svg_dir,
             tempfile.TemporaryDirectory(prefix="campost-rhwp-pdf-") as pdf_dir,
@@ -281,26 +334,39 @@ def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict
             temp_pdf_path = pdf_root / "preview.pdf"
             _build_svg_print_html(svg_paths, html_path)
 
-            chrome_completed = subprocess.run(
-                [
-                    chrome,
-                    "--headless=new",
-                    "--disable-gpu",
-                    "--no-sandbox",
-                    "--disable-dev-shm-usage",
-                    "--no-pdf-header-footer",
-                    f"--print-to-pdf={temp_pdf_path}",
-                    html_path.resolve().as_uri(),
-                ],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=PDF_CONVERSION_TIMEOUT_SECONDS,
-                check=False,
-            )
+            chrome_attempts = [
+                ("--headless=new", False),
+                ("--headless", False),
+                ("--headless=new", True),
+                ("--headless", True),
+            ]
+            for headless, no_sandbox in chrome_attempts:
+                temp_pdf_path.unlink(missing_ok=True)
+                chrome_completed = subprocess.run(
+                    _chrome_args(
+                        chrome,
+                        temp_pdf_path,
+                        html_path,
+                        headless=headless,
+                        no_sandbox=no_sandbox,
+                    ),
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=PDF_CONVERSION_TIMEOUT_SECONDS,
+                    check=False,
+                )
+                if (
+                    chrome_completed.returncode == 0
+                    and temp_pdf_path.exists()
+                    and temp_pdf_path.stat().st_size > 0
+                ):
+                    break
+
             if (
-                chrome_completed.returncode == 0
+                chrome_completed
+                and chrome_completed.returncode == 0
                 and temp_pdf_path.exists()
                 and temp_pdf_path.stat().st_size > 0
             ):
@@ -315,9 +381,10 @@ def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict
         return _default_pdf_preview_metadata("failed", str(exc))
 
     if not converted:
-        if output_path.exists():
-            output_path.unlink(missing_ok=True)
-        error = (chrome_completed.stderr or chrome_completed.stdout or "PDF output was not created").strip()
+        error = "PDF output was not created"
+        if chrome_completed:
+            error = chrome_completed.stderr or chrome_completed.stdout or error
+        error = error.strip()
         return _default_pdf_preview_metadata("failed", error[:500])
 
     return _pdf_preview_success_metadata(output_path)

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -53,9 +53,16 @@ class FileHandlerTests(unittest.TestCase):
 
     def test_convert_to_pdf_preview_records_success_metadata(self):
         def fake_run(cmd, **_kwargs):
-            out_dir = Path(cmd[cmd.index("--outdir") + 1])
-            source = Path(cmd[-1])
-            (out_dir / source.with_suffix(".pdf").name).write_bytes(b"%PDF-preview")
+            if cmd[1] == "export-svg":
+                out_dir = Path(cmd[cmd.index("-o") + 1])
+                (out_dir / "page_0001.svg").write_text(
+                    '<svg width="100" height="200" viewBox="0 0 100 200"></svg>',
+                    encoding="utf-8",
+                )
+                return subprocess.CompletedProcess(cmd, 0, "exported", "")
+
+            pdf_arg = next(arg for arg in cmd if arg.startswith("--print-to-pdf="))
+            Path(pdf_arg.split("=", 1)[1]).write_bytes(b"%PDF-preview")
             return subprocess.CompletedProcess(cmd, 0, "converted", "")
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -65,22 +72,30 @@ class FileHandlerTests(unittest.TestCase):
             with (
                 patch.object(file_handler, "PDF_CONVERSION_ENABLED", True),
                 patch.object(file_handler, "PDF_PREVIEW_EXTS", {"hwp", "hwpx"}),
-                patch.object(file_handler, "_find_libreoffice", return_value="soffice"),
+                patch.object(file_handler, "_find_rhwp", return_value="rhwp"),
+                patch.object(file_handler, "_find_chrome", return_value="chrome"),
                 patch.object(file_handler.subprocess, "run", side_effect=fake_run),
             ):
                 metadata = convert_to_pdf_preview(path, "hwp")
 
         self.assertEqual(metadata["conversion_status"], "success")
-        self.assertEqual(metadata["conversion_engine"], "libreoffice")
+        self.assertEqual(metadata["conversion_engine"], "rhwp+chrome")
         self.assertEqual(metadata["preview_pdf_path"], "files/sample.hwp.preview.pdf")
         self.assertEqual(metadata["preview_pdf_size"], len(b"%PDF-preview"))
         self.assertRegex(metadata["preview_pdf_checksum"], r"^[0-9a-f]{64}$")
 
     def test_convert_to_pdf_preview_does_not_overwrite_pdf_attachment(self):
         def fake_run(cmd, **_kwargs):
-            out_dir = Path(cmd[cmd.index("--outdir") + 1])
-            source = Path(cmd[-1])
-            (out_dir / source.with_suffix(".pdf").name).write_bytes(b"%PDF-preview")
+            if cmd[1] == "export-svg":
+                out_dir = Path(cmd[cmd.index("-o") + 1])
+                (out_dir / "page_0001.svg").write_text(
+                    '<svg width="100" height="200" viewBox="0 0 100 200"></svg>',
+                    encoding="utf-8",
+                )
+                return subprocess.CompletedProcess(cmd, 0, "exported", "")
+
+            pdf_arg = next(arg for arg in cmd if arg.startswith("--print-to-pdf="))
+            Path(pdf_arg.split("=", 1)[1]).write_bytes(b"%PDF-preview")
             return subprocess.CompletedProcess(cmd, 0, "converted", "")
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -92,7 +107,8 @@ class FileHandlerTests(unittest.TestCase):
             with (
                 patch.object(file_handler, "PDF_CONVERSION_ENABLED", True),
                 patch.object(file_handler, "PDF_PREVIEW_EXTS", {"hwp", "hwpx"}),
-                patch.object(file_handler, "_find_libreoffice", return_value="soffice"),
+                patch.object(file_handler, "_find_rhwp", return_value="rhwp"),
+                patch.object(file_handler, "_find_chrome", return_value="chrome"),
                 patch.object(file_handler.subprocess, "run", side_effect=fake_run),
             ):
                 metadata = convert_to_pdf_preview(path, "hwp")
@@ -111,7 +127,8 @@ class FileHandlerTests(unittest.TestCase):
             with (
                 patch.object(file_handler, "PDF_CONVERSION_ENABLED", True),
                 patch.object(file_handler, "PDF_PREVIEW_EXTS", {"hwp", "hwpx"}),
-                patch.object(file_handler, "_find_libreoffice", return_value="soffice"),
+                patch.object(file_handler, "_find_rhwp", return_value="rhwp"),
+                patch.object(file_handler, "_find_chrome", return_value="chrome"),
                 patch.object(file_handler.subprocess, "run") as run,
             ):
                 metadata = convert_to_pdf_preview(path, "hwp")
@@ -122,6 +139,12 @@ class FileHandlerTests(unittest.TestCase):
 
     def test_convert_to_pdf_preview_does_not_report_stale_preview_as_success(self):
         def fake_run_without_output(cmd, **_kwargs):
+            if cmd[1] == "export-svg":
+                out_dir = Path(cmd[cmd.index("-o") + 1])
+                (out_dir / "page_0001.svg").write_text(
+                    '<svg width="100" height="200" viewBox="0 0 100 200"></svg>',
+                    encoding="utf-8",
+                )
             return subprocess.CompletedProcess(cmd, 0, "converted", "")
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -133,17 +156,18 @@ class FileHandlerTests(unittest.TestCase):
             with (
                 patch.object(file_handler, "PDF_CONVERSION_ENABLED", True),
                 patch.object(file_handler, "PDF_PREVIEW_EXTS", {"hwp", "hwpx"}),
-                patch.object(file_handler, "_find_libreoffice", return_value="soffice"),
+                patch.object(file_handler, "_find_rhwp", return_value="rhwp"),
+                patch.object(file_handler, "_find_chrome", return_value="chrome"),
                 patch.object(file_handler.subprocess, "run", side_effect=fake_run_without_output),
             ):
                 metadata = convert_to_pdf_preview(path, "hwp", force=True)
-            preview_bytes = preview.read_bytes()
+            preview_exists = preview.exists()
 
-        self.assertEqual(preview_bytes, b"old preview")
+        self.assertFalse(preview_exists)
         self.assertEqual(metadata["conversion_status"], "failed")
         self.assertIsNone(metadata["preview_pdf_path"])
 
-    def test_convert_to_pdf_preview_marks_converter_unavailable(self):
+    def test_convert_to_pdf_preview_marks_rhwp_unavailable(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "sample.hwp"
             path.write_bytes(b"hwp")
@@ -151,7 +175,7 @@ class FileHandlerTests(unittest.TestCase):
             with (
                 patch.object(file_handler, "PDF_CONVERSION_ENABLED", True),
                 patch.object(file_handler, "PDF_PREVIEW_EXTS", {"hwp", "hwpx"}),
-                patch.object(file_handler, "_find_libreoffice", return_value=None),
+                patch.object(file_handler, "_find_rhwp", return_value=None),
             ):
                 metadata = convert_to_pdf_preview(path, "hwp")
 
@@ -293,7 +317,7 @@ class AttachmentCacheTests(unittest.IsolatedAsyncioTestCase):
                 patch.object(file_handler, "PDF_PREVIEW_EXTS", {"hwp", "hwpx"}),
                 patch.object(file_handler, "download_file", new=AsyncMock(side_effect=fake_download)),
                 patch.object(file_handler, "extract_text", return_value=("HWP text", "pyhwp_bodytext")),
-                patch.object(file_handler, "_find_libreoffice", return_value=None),
+                patch.object(file_handler, "_find_rhwp", return_value=None),
             ):
                 results = await process_attachments(
                     [{"name": "sample.hwp", "url": "https://example.test/sample.hwp", "ext": "hwp"}],

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -161,11 +161,31 @@ class FileHandlerTests(unittest.TestCase):
                 patch.object(file_handler.subprocess, "run", side_effect=fake_run_without_output),
             ):
                 metadata = convert_to_pdf_preview(path, "hwp", force=True)
-            preview_exists = preview.exists()
+            preview_bytes = preview.read_bytes()
 
-        self.assertFalse(preview_exists)
+        self.assertEqual(preview_bytes, b"old preview")
         self.assertEqual(metadata["conversion_status"], "failed")
         self.assertIsNone(metadata["preview_pdf_path"])
+
+    def test_extract_svg_size_accepts_valid_svg_format_variants(self):
+        cases = [
+            ("<svg width = '100.5' height = '200'></svg>", (100.5, 200.0)),
+            ('<svg viewBox="0, 0, 300, 400"></svg>', (300.0, 400.0)),
+            ("<svg viewBox='-1 -2 500 600'></svg>", (500.0, 600.0)),
+        ]
+
+        for svg, expected in cases:
+            with self.subTest(svg=svg):
+                self.assertEqual(file_handler._extract_svg_size(svg), expected)
+
+    def test_chrome_args_only_disables_sandbox_for_root_user(self):
+        with patch.object(file_handler.os, "geteuid", return_value=1000, create=True):
+            args = file_handler._chrome_args("chrome", Path("out.pdf"), Path.cwd(), headless="--headless")
+        self.assertNotIn("--no-sandbox", args)
+
+        with patch.object(file_handler.os, "geteuid", return_value=0, create=True):
+            args = file_handler._chrome_args("chrome", Path("out.pdf"), Path.cwd(), headless="--headless")
+        self.assertIn("--no-sandbox", args)
 
     def test_convert_to_pdf_preview_marks_rhwp_unavailable(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #32 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 예: 리뷰 작성 API 개발
- 예: Prisma 모델 수정
HWP/HWPX 첨부파일의 PDF 미리보기 변환 엔진을 기존 LibreOffice 방식에서 RHWP + Chrome Headless 방식으로 교체했습니다.

  기존 LibreOffice 변환은 일부 학교 HWP 파일에서 source file could not be loaded 오류가 발생해 PDF 생성 실패율이 높았습
  니다. 이를 개선하기 위해 RHWP CLI로 HWP/HWPX 파일을 페이지별 SVG로 렌더링하고, 생성된 SVG를 임시 HTML로 묶은 뒤 Chrome
  Headless의 PDF 출력 기능으로 최종 PDF preview 파일을 생성하도록 변경했습니다.

  주요 변경 사항:

  - LibreOffice 기반 변환 로직 제거
  - RHWP CLI 자동 탐지 로직 추가
  - Chrome/Chromium Headless 자동 탐지 로직 추가
  - HWP/HWPX → SVG → PDF 변환 파이프라인 구현
  - 변환 결과 파일명을 {원본파일명}.preview.pdf로 저장해 기존 PDF 첨부파일 덮어쓰기 방지
  - 기존 preview PDF가 원본보다 최신이고 정상 파일이면 재변환하지 않도록 캐싱 처리
  - 변환 작업을 asyncio.to_thread()로 실행해 크롤러 이벤트 루프 차단 방지
  - Docker 환경에 RHWP CLI 설치 추가
  - Docker base image를 python:3.12-slim-bookworm으로 고정해 apt 빌드 안정성 확보
  - 환경 변수 RHWP_BIN, CHROME_BIN 추가
  - 변환 성공/실패 메타데이터를 기존 첨부파일 row에 기록
      - preview_pdf_path
      - preview_pdf_size
      - preview_pdf_checksum
      - conversion_status
      - conversion_engine
      - conversion_error

  수정 파일:

  - crawler/file_handler.py
  - crawler/config.py
  - .env.example
  - Dockerfile
  - tests/test_file_handler.py

  검증 결과:

  - RHWP CLI v0.7.10 동작 확인
  - Docker 이미지 빌드 성공
  - 컨테이너 내부에서 RHWP 및 Chrome Headless 자동 탐지 확인
  - 실제 HWP 파일 PDF 변환 성공
  - SW_175482 공지의 HWP 첨부파일 변환 성공
  - 백엔드 API에서 previewPdfPath, conversionStatus: success, conversionEngine: rhwp+chrome 반환 확인
  - 단위 테스트 통과

  현재 동작 방식:

  1. HWP/HWPX 첨부파일 다운로드
  2. RHWP CLI로 페이지별 SVG 생성
  3. SVG들을 임시 HTML로 구성
  4. Chrome Headless로 PDF 출력
  5. 생성된 PDF를 *.hwp.preview.pdf 또는 *.hwpx.preview.pdf 형태로 저장
  6. 변환 메타데이터를 raw JSON 및 DB에 반영
  7. 프론트에서는 conversionStatus === "success"이고 previewPdfPath가 있을 때 PDF 미리보기로 표시 가능

  참고:
  기존에 이미 LibreOffice 변환 실패 상태로 저장된 과거 HWP 파일들은 자동으로 다시 변환되지 않습니다. 과거 데이터까지 적
  용하려면 백필 스크립트를 실행해야 합니다.




## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * HWP/HWPX 문서의 PDF 미리보기 생성 엔진을 개선했습니다.
  * 문서 변환 구성 요소를 업데이트했습니다.
  * 컨테이너 환경을 최적화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-pipeline/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->