### PR TITLE
Feat(#35): Cloudflare R2 파일 업로드 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,13 @@ PDF_PREVIEW_EXTS=hwp,hwpx
 # Optional. Leave empty to auto-detect rhwp and Playwright Chromium/Chrome.
 RHWP_BIN=
 CHROME_BIN=
+
+# ── Cloudflare R2 Object Storage ──
+# 미설정 시 R2 업로드 비활성화 (local_path만 저장됨)
+# Cloudflare Dashboard > R2 > 버킷 > Settings에서 확인
+R2_ACCOUNT_ID=<REQUIRED>
+R2_ACCESS_KEY_ID=<REQUIRED>
+R2_SECRET_ACCESS_KEY=<REQUIRED>
+R2_BUCKET_NAME=campost-files
+# 버킷 Public Access 활성화 후 나오는 r2.dev URL
+R2_PUBLIC_URL=https://pub-xxxx.r2.dev

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -149,3 +149,13 @@ DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "")
 GEMINI_API_KEY: str = os.getenv("GEMINI_API_KEY", "")
 GEMINI_MODEL: str = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 AI_ENABLED: bool = bool(GEMINI_API_KEY)
+
+# ── Cloudflare R2 Object Storage ─────────────────────────
+R2_ACCOUNT_ID: str = os.getenv("R2_ACCOUNT_ID", "").strip()
+R2_ACCESS_KEY_ID: str = os.getenv("R2_ACCESS_KEY_ID", "").strip()
+R2_SECRET_ACCESS_KEY: str = os.getenv("R2_SECRET_ACCESS_KEY", "").strip()
+R2_BUCKET_NAME: str = os.getenv("R2_BUCKET_NAME", "campost-files").strip()
+R2_PUBLIC_URL: str = os.getenv("R2_PUBLIC_URL", "").strip()
+R2_ENABLED: bool = bool(
+    R2_ACCOUNT_ID and R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY and R2_PUBLIC_URL
+)

--- a/crawler/file_handler.py
+++ b/crawler/file_handler.py
@@ -36,10 +36,13 @@ from .config import (
     RHWP_BIN,
     USER_AGENT,
 )
+from .r2_uploader import upload_to_r2
 
 mimetypes.add_type("application/x-hwp", ".hwp")
 mimetypes.add_type("application/x-hwpx", ".hwpx")
-mimetypes.add_type("application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx")
+mimetypes.add_type(
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"
+)
 
 log = logging.getLogger("campost.file_handler")
 logging.getLogger("hwp5").setLevel(logging.WARNING)
@@ -327,7 +330,11 @@ def convert_to_pdf_preview(path: Path, ext: str, *, force: bool = False) -> dict
             )
             svg_paths = sorted(svg_root.glob("*.svg"))
             if rhwp_completed.returncode != 0 or not svg_paths:
-                error = (rhwp_completed.stderr or rhwp_completed.stdout or "RHWP SVG output was not created").strip()
+                error = (
+                    rhwp_completed.stderr
+                    or rhwp_completed.stdout
+                    or "RHWP SVG output was not created"
+                ).strip()
                 return _default_pdf_preview_metadata("failed", error[:500])
 
             html_path = svg_root / "preview.html"
@@ -649,7 +656,11 @@ async def extract_external_images(body_html: str, article_id: str) -> list[dict]
         if raw_ext not in ("jpg", "jpeg", "png", "gif", "webp", "svg"):
             raw_ext = "jpg"
 
-        mime_type = "image/svg+xml" if raw_ext == "svg" else "image/" + ("jpeg" if raw_ext == "jpg" else raw_ext)
+        mime_type = (
+            "image/svg+xml"
+            if raw_ext == "svg"
+            else "image/" + ("jpeg" if raw_ext == "jpg" else raw_ext)
+        )
 
         filename = _safe_filename(article_id, f"ext_img_{count}.{raw_ext}")
         save_path = FILES_DIR / filename
@@ -660,21 +671,25 @@ async def extract_external_images(body_html: str, article_id: str) -> list[dict]
 
         file_size = save_path.stat().st_size
         checksum = _compute_checksum(save_path)
+        r2_url = upload_to_r2(save_path, f"files/{filename}", mime_type)
         log.info(f"  외부 이미지 저장: {filename} ({file_size:,} bytes)")
-        results.append({
-            "name": filename,
-            "url": url,
-            "ext": raw_ext,
-            "file_key": filename,
-            "local_path": f"files/{filename}",
-            "mime_type": mime_type,
-            "file_size": file_size,
-            "checksum": checksum,
-            "extracted_text": "",
-            "download_ok": True,
-            "parser": "none",
-            "parse_ok": False,
-        })
+        results.append(
+            {
+                "name": filename,
+                "url": url,
+                "ext": raw_ext,
+                "file_key": filename,
+                "local_path": f"files/{filename}",
+                "r2_url": r2_url,
+                "mime_type": mime_type,
+                "file_size": file_size,
+                "checksum": checksum,
+                "extracted_text": "",
+                "download_ok": True,
+                "parser": "none",
+                "parse_ok": False,
+            }
+        )
         count += 1
 
     return results
@@ -686,7 +701,7 @@ def extract_inline_images(body_html: str, article_id: str) -> list[dict]:
     이미지 전용 공지(텍스트 없이 포스터 이미지만 있는 경우)를 처리하기 위해 사용.
     최대 10개, 개당 10MB 초과 시 건너뜀.
     """
-    pattern = r'data:image/(jpeg|png|gif|webp);base64,([A-Za-z0-9+/=]+)'
+    pattern = r"data:image/(jpeg|png|gif|webp);base64,([A-Za-z0-9+/=]+)"
     matches = re.findall(pattern, body_html)
 
     if len(matches) > _MAX_INLINE_IMAGES:
@@ -714,21 +729,25 @@ def extract_inline_images(body_html: str, article_id: str) -> list[dict]:
             save_path.write_bytes(base64.b64decode(b64_data, validate=True))
             file_size = save_path.stat().st_size
             checksum = _compute_checksum(save_path)
+            r2_url = upload_to_r2(save_path, f"files/{filename}", f"image/{img_type}")
             log.info(f"  인라인 이미지 저장: {filename} ({file_size:,} bytes)")
-            results.append({
-                "name": filename,
-                "url": "",
-                "ext": ext,
-                "file_key": filename,
-                "local_path": f"files/{filename}",
-                "mime_type": f"image/{img_type}",
-                "file_size": file_size,
-                "checksum": checksum,
-                "extracted_text": "",
-                "download_ok": True,
-                "parser": "none",
-                "parse_ok": False,
-            })
+            results.append(
+                {
+                    "name": filename,
+                    "url": "",
+                    "ext": ext,
+                    "file_key": filename,
+                    "local_path": f"files/{filename}",
+                    "r2_url": r2_url,
+                    "mime_type": f"image/{img_type}",
+                    "file_size": file_size,
+                    "checksum": checksum,
+                    "extracted_text": "",
+                    "download_ok": True,
+                    "parser": "none",
+                    "parse_ok": False,
+                }
+            )
         except Exception as exc:
             log.warning(f"  인라인 이미지 저장 실패 ({filename}): {exc}")
     return results
@@ -794,14 +813,31 @@ async def process_attachments(attachments: list[dict], article_id: str) -> list[
         )
         file_key = filename
         checksum = _compute_checksum(save_path) if download_ok else None
-        file_size = cached_file_size if download_cached else save_path.stat().st_size if download_ok else None
+        file_size = (
+            cached_file_size
+            if download_cached
+            else save_path.stat().st_size
+            if download_ok
+            else None
+        )
         mime_type = _get_mime_type(att["name"])
+
+        r2_url = upload_to_r2(save_path, f"files/{filename}", mime_type) if download_ok else None
+
+        preview_pdf_r2_url = None
+        if pdf_preview["conversion_status"] == "success":
+            preview_path = _pdf_preview_path(save_path)
+            preview_pdf_r2_url = upload_to_r2(
+                preview_path, f"files/{preview_path.name}", "application/pdf"
+            )
 
         results.append(
             {
                 **att,
                 "file_key": file_key,
                 "local_path": f"files/{filename}",
+                "r2_url": r2_url,
+                "preview_pdf_r2_url": preview_pdf_r2_url,
                 "mime_type": mime_type,
                 "file_size": file_size,
                 "checksum": checksum,

--- a/crawler/file_handler.py
+++ b/crawler/file_handler.py
@@ -671,7 +671,7 @@ async def extract_external_images(body_html: str, article_id: str) -> list[dict]
 
         file_size = save_path.stat().st_size
         checksum = _compute_checksum(save_path)
-        r2_url = upload_to_r2(save_path, f"files/{filename}", mime_type)
+        r2_url = await asyncio.to_thread(upload_to_r2, save_path, f"files/{filename}", mime_type)
         log.info(f"  외부 이미지 저장: {filename} ({file_size:,} bytes)")
         results.append(
             {
@@ -822,13 +822,17 @@ async def process_attachments(attachments: list[dict], article_id: str) -> list[
         )
         mime_type = _get_mime_type(att["name"])
 
-        r2_url = upload_to_r2(save_path, f"files/{filename}", mime_type) if download_ok else None
+        r2_url = (
+            await asyncio.to_thread(upload_to_r2, save_path, f"files/{filename}", mime_type)
+            if download_ok
+            else None
+        )
 
         preview_pdf_r2_url = None
         if pdf_preview["conversion_status"] == "success":
             preview_path = _pdf_preview_path(save_path)
-            preview_pdf_r2_url = upload_to_r2(
-                preview_path, f"files/{preview_path.name}", "application/pdf"
+            preview_pdf_r2_url = await asyncio.to_thread(
+                upload_to_r2, preview_path, f"files/{preview_path.name}", "application/pdf"
             )
 
         results.append(

--- a/crawler/r2_uploader.py
+++ b/crawler/r2_uploader.py
@@ -1,0 +1,48 @@
+"""Cloudflare R2 upload helper (S3-compatible API via boto3)."""
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger("campost.r2")
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is not None:
+        return _client
+    import boto3
+
+    from .config import R2_ACCESS_KEY_ID, R2_ACCOUNT_ID, R2_SECRET_ACCESS_KEY
+
+    _client = boto3.client(
+        "s3",
+        endpoint_url=f"https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com",
+        aws_access_key_id=R2_ACCESS_KEY_ID,
+        aws_secret_access_key=R2_SECRET_ACCESS_KEY,
+        region_name="auto",
+    )
+    return _client
+
+
+def upload_to_r2(local_path: Path, object_key: str, content_type: str) -> str | None:
+    """Upload a local file to R2. Returns public URL or None on failure/disabled."""
+    from .config import R2_BUCKET_NAME, R2_ENABLED, R2_PUBLIC_URL
+
+    if not R2_ENABLED:
+        return None
+    try:
+        client = _get_client()
+        client.upload_file(
+            str(local_path),
+            R2_BUCKET_NAME,
+            object_key,
+            ExtraArgs={"ContentType": content_type},
+        )
+        url = f"{R2_PUBLIC_URL.rstrip('/')}/{object_key}"
+        log.debug(f"R2 업로드 완료: {object_key}")
+        return url
+    except Exception as exc:
+        log.warning(f"R2 업로드 실패 ({object_key}): {exc}")
+        return None

--- a/crawler/r2_uploader.py
+++ b/crawler/r2_uploader.py
@@ -3,7 +3,16 @@
 import logging
 from pathlib import Path
 
+from botocore.config import Config
+
 log = logging.getLogger("campost.r2")
+
+# boto3 1.36+ sends checksum headers by default; R2 does not support them.
+# "when_required" disables automatic checksum injection for standard uploads.
+_R2_CONFIG = Config(
+    request_checksum_calculation="when_required",
+    response_checksum_validation="when_required",
+)
 
 _client = None
 
@@ -22,6 +31,7 @@ def _get_client():
         aws_access_key_id=R2_ACCESS_KEY_ID,
         aws_secret_access_key=R2_SECRET_ACCESS_KEY,
         region_name="auto",
+        config=_R2_CONFIG,
     )
     return _client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary>=2.9
 google-genai>=1.0
 pyhwp>=0.1b15
 six>=1.16
+boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ psycopg2-binary>=2.9
 google-genai>=1.0
 pyhwp>=0.1b15
 six>=1.16
-boto3>=1.34
+boto3>=1.36.5


### PR DESCRIPTION
## 개요
파이프라인에서 수집한 첨부파일(HWP→PDF 변환본, 이미지 등)을 Cloudflare R2 Object Storage에 업로드하여 배포 환경에서도 파일 접근이 가능하도록 한다.

## 변경 파일
- `requirements.txt` — `boto3>=1.34` 추가
- `crawler/config.py` — R2 환경변수 (R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME, R2_PUBLIC_URL, R2_ENABLED) 추가
- `crawler/r2_uploader.py` — 신규 생성. S3 호환 R2 업로드 유틸 (boto3, lazy 클라이언트 초기화)
- `crawler/file_handler.py` — `process_attachments`, `extract_external_images`, `extract_inline_images`에 R2 업로드 호출 추가. 결과 dict에 `r2_url`, `preview_pdf_r2_url` 필드 포함
- `.env.example` — R2 섹션 추가

## 동작 방식
- `R2_ENABLED=True`일 때만 업로드 시도 (4개 환경변수 모두 설정 시 자동 활성화)
- 업로드 실패 시 warning 로그만 남기고 크롤링 계속 진행 (best-effort)
- `r2_url`, `preview_pdf_r2_url`이 raw JSON에 포함되어 백엔드 importer가 DB에 저장

## 테스트 결과
- R2 환경변수 설정 후 파이프라인 실행 시 R2 버킷에 파일 업로드 확인 필요

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Cloudflare R2 Object Storage 통합 추가
  * 외부 이미지, 인라인 이미지, 첨부파일 자동 업로드 지원
  * PDF 미리보기 파일 업로드 기능 포함
  * 환경변수 설정으로 R2 저장소 활성화/비활성화 가능

* **기타**
  * 의존성 라이브러리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->