### PR TITLE
Fix(#37): content_html 이미지 src R2 URL 우선 적용

### DIFF
--- a/crawler/content.py
+++ b/crawler/content.py
@@ -189,19 +189,20 @@ def _rewrite_body_image_sources(
             continue
 
         local_path = attachment["local_path"]
+        display_src = attachment.get("r2_url") or local_path
         file_key = attachment.get("file_key") or attachment.get("name") or local_path
         used_file_keys.add(file_key)
         body_images.append(
             {
                 "file_key": file_key,
                 "name": attachment.get("name") or file_key,
-                "src": local_path,
+                "src": display_src,
                 "original_src": src,
                 "mime_type": attachment.get("mime_type"),
                 "file_size": attachment.get("file_size"),
             }
         )
-        image["src"] = local_path
+        image["src"] = display_src
         image.attrs.pop("srcset", None)
         image.attrs.pop("sizes", None)
 
@@ -229,7 +230,7 @@ def _image_attachment_gallery(
             continue
 
         name = attachment.get("name") or file_key
-        src = attachment["local_path"]
+        src = attachment.get("r2_url") or attachment["local_path"]
         gallery_images.append(
             {
                 "file_key": file_key,
@@ -241,9 +242,9 @@ def _image_attachment_gallery(
             }
         )
         figures.append(
-            "<figure class=\"notice-content-image\">"
-            f"<img src=\"{html.escape(src, quote=True)}\" "
-            f"alt=\"{html.escape(name, quote=True)}\" loading=\"lazy\">"
+            '<figure class="notice-content-image">'
+            f'<img src="{html.escape(src, quote=True)}" '
+            f'alt="{html.escape(name, quote=True)}" loading="lazy">'
             f"<figcaption>{html.escape(name)}</figcaption>"
             "</figure>"
         )
@@ -252,9 +253,7 @@ def _image_attachment_gallery(
         return "", gallery_images
 
     return (
-        "<section class=\"notice-content-image-attachments\">"
-        + "".join(figures)
-        + "</section>"
+        '<section class="notice-content-image-attachments">' + "".join(figures) + "</section>"
     ), gallery_images
 
 


### PR DESCRIPTION
## 원인
`content.py`의 `_rewrite_body_image_sources`와 `_image_attachment_gallery`가 이미지 `src`를 항상 `local_path`(`files/xxx.png`)로 고정하여 배포 환경에서 백엔드로 요청이 가고 500 에러 발생.

## 변경 내용
- `_rewrite_body_image_sources` — `r2_url` 우선 사용, 없을 때 `local_path` fallback
- `_image_attachment_gallery` — 동일 처리

## 효과
- `content_html`의 `<img src>` → R2 직접 URL 포함
- `content_assets.images[].src` → R2 URL 저장 (썸네일도 R2에서 로드)

## 주의
머지 후 파이프라인 재실행 및 임포터 재실행 필요 (기존 DB의 content_html은 여전히 local_path 포함).

Closes #37