### PR TITLE
Feat(#43): pdf뷰어의 이미지가 짤리는 현상 수정 

### DIFF
--- a/crawler/file_handler.py
+++ b/crawler/file_handler.py
@@ -52,6 +52,9 @@ _MAX_INLINE_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MB
 _A4_WIDTH_PX = 793.7066666666667
 _A4_HEIGHT_PX = 1122.5066666666667
 _SVG_ATTR_NUMBER = r"([-+]?(?:\d+(?:\.\d*)?|\.\d+))"
+# 콘텐츠가 페이지 밖으로 넘칠 때 페이지를 넓혀 잘림을 방지하기 위한 값
+_OVERFLOW_TOLERANCE = 2.0  # 이 값(px) 초과로 넘칠 때만 페이지 확장 (반올림 오차 무시)
+_OVERFLOW_PAD = 8.0  # 확장 시 우측/하단에 더해줄 여백(px)
 
 
 def _safe_filename(article_id: str, name: str) -> str:
@@ -234,24 +237,107 @@ def _extract_svg_size(svg: str) -> tuple[float, float]:
     return _A4_WIDTH_PX, _A4_HEIGHT_PX
 
 
+def _svg_content_extent(svg: str) -> tuple[float, float]:
+    """rect/image 요소 기준 콘텐츠의 우측·하단 끝(px)을 추정한다.
+
+    HWP 표가 페이지보다 넓게 작성된 경우 rect 셀이 페이지 폭을 넘어가므로,
+    이 값으로 잘림 여부를 판단한다. (텍스트만으로 넘치는 드문 경우는 잡지 못함)
+
+    주의: <defs> 안의 clipPath/mask/pattern 정의는 실제로 그려지는 콘텐츠가
+    아니므로(보통 페이지보다 큰 클리핑 영역을 정의함) 계산에서 제외한다.
+    """
+    svg = re.sub(r"<defs\b[^>]*>.*?</defs>", "", svg, flags=re.IGNORECASE | re.DOTALL)
+    right = 0.0
+    bottom = 0.0
+    for match in re.finditer(
+        rf"<(?:rect|image)\b[^>]*?\bx\s*=\s*['\"]\s*{_SVG_ATTR_NUMBER}[^>]*?\bwidth\s*=\s*['\"]\s*{_SVG_ATTR_NUMBER}",
+        svg,
+        re.IGNORECASE,
+    ):
+        right = max(right, float(match.group(1)) + float(match.group(2)))
+    for match in re.finditer(
+        rf"<(?:rect|image)\b[^>]*?\by\s*=\s*['\"]\s*{_SVG_ATTR_NUMBER}[^>]*?\bheight\s*=\s*['\"]\s*{_SVG_ATTR_NUMBER}",
+        svg,
+        re.IGNORECASE,
+    ):
+        bottom = max(bottom, float(match.group(1)) + float(match.group(2)))
+    return right, bottom
+
+
+def _fit_svg_viewport(svg: str, width: float, height: float) -> str:
+    """svg 루트의 width/height/viewBox 를 지정 크기로 맞춰 전체 콘텐츠가 보이게 한다."""
+
+    def _replace_root(match: re.Match) -> str:
+        tag = match.group(0)
+        if re.search(r"\bwidth\s*=", tag, re.IGNORECASE):
+            tag = re.sub(
+                r"\bwidth\s*=\s*['\"][^'\"]*['\"]",
+                f'width="{width}"',
+                tag,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        if re.search(r"\bheight\s*=", tag, re.IGNORECASE):
+            tag = re.sub(
+                r"\bheight\s*=\s*['\"][^'\"]*['\"]",
+                f'height="{height}"',
+                tag,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        if re.search(r"\bviewBox\s*=", tag, re.IGNORECASE):
+            tag = re.sub(
+                r"\bviewBox\s*=\s*['\"][^'\"]*['\"]",
+                f'viewBox="0 0 {width} {height}"',
+                tag,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        else:
+            tag = tag[:-1].rstrip() + f' viewBox="0 0 {width} {height}">'
+        return tag
+
+    return re.sub(r"<svg\b[^>]*>", _replace_root, svg, count=1)
+
+
 def _build_svg_print_html(svg_paths: list[Path], html_path: Path) -> None:
-    first_svg = svg_paths[0].read_text(encoding="utf-8")
-    width, height = _extract_svg_size(first_svg)
-    pages = []
+    page_width = 0.0
+    page_height = 0.0
+    sections: list[tuple[str, float, float]] = []
     for svg_path in svg_paths:
         svg = svg_path.read_text(encoding="utf-8")
-        pages.append(f'<section class="page">{svg}</section>')
+        decl_width, decl_height = _extract_svg_size(svg)
+        content_right, content_bottom = _svg_content_extent(svg)
+
+        # 콘텐츠가 선언 페이지 크기를 의미 있게(_OVERFLOW_TOLERANCE 초과) 넘을 때만
+        # 페이지/viewBox 를 넓혀 잘림을 방지한다. 정상 문서는 decl 값 그대로 유지되어
+        # 기존 렌더링과 동일하게 동작한다.
+        eff_width = decl_width
+        eff_height = decl_height
+        if content_right > decl_width + _OVERFLOW_TOLERANCE:
+            eff_width = content_right + _OVERFLOW_PAD
+        if content_bottom > decl_height + _OVERFLOW_TOLERANCE:
+            eff_height = content_bottom + _OVERFLOW_PAD
+        if eff_width != decl_width or eff_height != decl_height:
+            svg = _fit_svg_viewport(svg, eff_width, eff_height)
+
+        sections.append((svg, eff_width, eff_height))
+        page_width = max(page_width, eff_width)
+        page_height = max(page_height, eff_height)
+
+    pages = [
+        f'<section class="page" style="width: {w}px; height: {h}px;">{svg}</section>'
+        for svg, w, h in sections
+    ]
 
     html = f"""<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
 <style>
-@page {{ size: {width}px {height}px; margin: 0; }}
+@page {{ size: {page_width}px {page_height}px; margin: 0; }}
 html, body {{ margin: 0; padding: 0; background: white; }}
 .page {{
-  width: {width}px;
-  height: {height}px;
   margin: 0;
   padding: 0;
   overflow: hidden;
@@ -264,8 +350,8 @@ html, body {{ margin: 0; padding: 0; background: white; }}
 }}
 svg {{
   display: block;
-  width: {width}px;
-  height: {height}px;
+  width: 100%;
+  height: 100%;
 }}
 </style>
 </head>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+mkdir -p /data /ms-playwright
+
+if [ "$(id -u)" = "0" ]; then
+    chown -R app:app /data /ms-playwright
+    exec gosu app "$@"
+fi
+
+exec "$@"

--- a/scripts/repair_notice_metadata.py
+++ b/scripts/repair_notice_metadata.py
@@ -1,0 +1,37 @@
+"""Repair raw metadata for specific notices without touching content assets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+RAW_DIR = Path("/data/raw")
+
+PATCHES = {
+    "SW_175057": {
+        "author": "소프트웨어학과",
+        "date": "2026.05.13",
+        "views": "19",
+        "category": "행사 및 대회",
+    },
+    "SW_175082": {
+        "author": "소프트웨어학과",
+        "date": "2026.05.14",
+        "views": "29",
+        "category": "행사 및 대회",
+    },
+}
+
+
+def main() -> None:
+    for article_id, patch in PATCHES.items():
+        path = RAW_DIR / f"{article_id}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data.update(patch)
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"{article_id}: {patch}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #43 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 예: 리뷰 작성 API 개발
- 예: Prisma 모델 수정
✅ 수정한 파일 (딱 1개)

  CamPost-pipeline/crawler/file_handler.py (+95 / −9 줄)

  변경 내용:
  1. 상수 추가: _OVERFLOW_TOLERANCE = 2.0, _OVERFLOW_PAD = 8.0
  2. 신규 _svg_content_extent() — 콘텐츠의 실제 우측/하단 끝 계산.
  <defs>(clipPath 등 정의부)는 제외 ← false positive 방지의 핵심
  3. 신규 _fit_svg_viewport() — SVG 루트의 width/height/viewBox 재설정
  4. _build_svg_print_html() 재작성 — 콘텐츠가 페이지를 넘칠 때만 페이지를
  넓혀 잘림 방지 (정상 문서는 기존과 동일)

  🧪 검증 결과 (안전성 확인)

  로컬 HWP 49개 회귀 테스트:
  - 46개 = 변화 없음 (정상 문서는 그대로)
  - 3개만 확장 = 전부 진짜 잘리던 문서 (채용정보 +567px, 현장실습 안내 +33px
  ×2)
  - ☞ 처음엔 정상 문서까지 확장되는 버그가 있었는데(<defs>의 clipPath를
  콘텐츠로 오인), 그걸 제외하도록 고쳐 false positive 0건

  실제 rhwp+Chrome 변환(운영 동일 경로):
  - 채용정보 → 잘렸던 채용 표 5건이 전부, 정상 한글 폰트로 표시됨 ✅

  → 질문하셨던 "다른 파일이 이상해질 수 있냐"에 대한 답: 정상 문서는 안
  건드립니다. (넘침 감지 시에만 페이지를 넓힘)

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * SVG 렌더링 시 콘텐츠 잘림 현상 개선. 각 SVG별 실제 크기를 정확하게 계산하여 페이지마다 최적의 크기로 렌더링됩니다.

* **개선 사항**
  * Docker 환경 초기화 및 권한 관리 개선으로 더욱 안정적인 실행 환경 제공.

* **기타**
  * 메타데이터 관리 유틸리티 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->